### PR TITLE
[AD1.0] タグ、目標、トレーニング種目のEntity追加

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/ContactsView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/ContactsView.swift
@@ -13,7 +13,6 @@ import SwiftUI
 struct ContactsView: View {
     
     let store: StoreOf<ContactsFeature>
-    let entity = DiarySearchTagEntity(id: UUID(), tagName: "")
     
     var body: some View {
         // Push遷移の場合、NavigationStackStoreでラップ.

--- a/Macho/MachoFramework/Sources/RealmHelper/Entities/DiaryEntity.swift
+++ b/Macho/MachoFramework/Sources/RealmHelper/Entities/DiaryEntity.swift
@@ -1,0 +1,93 @@
+//
+//  DiaryEntity.swift
+//
+//  
+//  Created by Daiki Fujimori on 2024/08/31
+//  
+
+import Foundation
+import RealmSwift
+
+public struct DiaryEntity: BaseRealmEntity {
+    
+    public let id: UUID
+    /// 日付
+    public let date: Date
+    /// 日記タイトル
+    public let title: String
+    /// 日記本文
+    public let mainText: String
+    /// 目標種目リスト
+    public let goals: [TrainingGoalEntity]
+    /// タグリスト
+    public let tags: [TrainingTagEntity]
+    
+    public static let executor = RealmObserverExecutor<Self>()
+    
+    public init(id: UUID, date: Date, title: String, mainText: String,
+                goals: [TrainingGoalEntity], tags: [TrainingTagEntity]) {
+        
+        self.id = id
+        self.date = date
+        self.title = title
+        self.mainText = mainText
+        self.goals = goals
+        self.tags = tags
+    }
+    
+    public init(realmObject: DiaryRealmObject) {
+        
+        id = realmObject.id
+        date = realmObject.date
+        title = realmObject.title
+        mainText = realmObject.mainText
+        goals = realmObject.goals.map { TrainingGoalEntity(realmObject: $0) }
+        tags = realmObject.tags.map { TrainingTagEntity(realmObject: $0) }
+    }
+    
+    public func toRealmObject() -> DiaryRealmObject {
+        
+        let goalObjects = goals.reduce(List<TrainingGoalRealmObject>()) {
+            
+            $0.append($1.toRealmObject())
+            return $0
+        }
+        
+        let tagObjects = tags.reduce(List<TrainingTagRealmObject>()) {
+            
+            $0.append($1.toRealmObject())
+            return $0
+        }
+        
+        return DiaryRealmObject(id: id, date: date, title: title, mainText: mainText,
+                                goals: goalObjects, tags: tagObjects)
+    }
+}
+
+public class DiaryRealmObject: Object {
+    
+    @Persisted(primaryKey: true) var id: UUID
+    /// 日付
+    @Persisted var date: Date
+    /// 日記タイトル
+    @Persisted var title: String
+    /// 日記本文
+    @Persisted var mainText: String
+    /// 目標種目リスト
+    @Persisted var goals: List<TrainingGoalRealmObject>
+    /// タグリスト
+    @Persisted var tags: List<TrainingTagRealmObject>
+    
+    convenience init(id: UUID, date: Date, title: String, mainText: String,
+                     goals: List<TrainingGoalRealmObject>, tags: List<TrainingTagRealmObject>) {
+        
+        self.init()
+        
+        self.id = id
+        self.date = date
+        self.title = title
+        self.mainText = mainText
+        self.goals = goals
+        self.tags = tags
+    }
+}

--- a/Macho/MachoFramework/Sources/RealmHelper/Entities/TrainingGoalEntity.swift
+++ b/Macho/MachoFramework/Sources/RealmHelper/Entities/TrainingGoalEntity.swift
@@ -1,0 +1,83 @@
+//
+//  TrainingGoalEntity.swift
+//
+//  
+//  Created by Daiki Fujimori on 2024/04/13
+//
+
+import Foundation
+import RealmSwift
+
+public struct TrainingGoalEntity: BaseRealmEntity {
+    
+    public let id: UUID
+    /// 目標種目
+    public let goalType: TrainingTypeEntity
+    /// 1セットの回数
+    public let numberOfSets: Int
+    /// セット数
+    public let setCount: Int
+    /// 開始時間
+    public let startTime: Date?
+    /// 終了時間
+    public let endTime: Date?
+    /// トレーニング達成成否
+    public let isSuccess: Bool?
+    
+    public static let executor = RealmObserverExecutor<Self>()
+    
+    public init(id: UUID, goalType: TrainingTypeEntity, numberOfSets: Int,
+                setCount: Int, startTime: Date?, endTime: Date?, isSuccess: Bool?) {
+        
+        self.id = id
+        self.goalType = goalType
+        self.numberOfSets = numberOfSets
+        self.setCount = setCount
+        self.startTime = startTime
+        self.endTime = endTime
+        self.isSuccess = isSuccess
+    }
+    
+    public init(realmObject: TrainingGoalRealmObject) {
+        
+        id = realmObject.id
+        goalType = TrainingTypeEntity(realmObject: realmObject.goalType)
+        numberOfSets = realmObject.numberOfSets
+        setCount = realmObject.setCount
+        startTime = realmObject.startTime
+        endTime = realmObject.endTime
+        isSuccess = realmObject.isSuccess
+    }
+    
+    public func toRealmObject() -> TrainingGoalRealmObject {
+        
+        return TrainingGoalRealmObject(id: id, goalType: goalType.toRealmObject(), numberOfSets: numberOfSets,
+                                       setCount: setCount, startTime: startTime, endTime: endTime,
+                                       isSuccess: isSuccess)
+    }
+}
+
+public class TrainingGoalRealmObject: Object {
+    
+    @Persisted(primaryKey: true) var id: UUID
+    @Persisted var goalType: TrainingTypeRealmObject
+    @Persisted var numberOfSets: Int
+    @Persisted var setCount: Int
+    @Persisted var startTime: Date?
+    @Persisted var endTime: Date?
+    @Persisted var isSuccess: Bool?
+    
+    convenience init(id: UUID, goalType: TrainingTypeRealmObject, numberOfSets: Int,
+                     setCount: Int, startTime: Date?, endTime: Date?, isSuccess: Bool?) {
+        
+        self.init()
+        
+        self.id = id
+        self.goalType = goalType
+        self.numberOfSets = numberOfSets
+        self.setCount = setCount
+        self.startTime = startTime
+        self.endTime = endTime
+        self.isSuccess = isSuccess
+    }
+}

--- a/Macho/MachoFramework/Sources/RealmHelper/Entities/TrainingTagEntity.swift
+++ b/Macho/MachoFramework/Sources/RealmHelper/Entities/TrainingTagEntity.swift
@@ -1,5 +1,5 @@
 //
-//  DiarySearchTagEntity.swift
+//  TrainingTagEntity.swift
 //  Macho
 //
 //  Created by 佐藤汰一 on 2023/11/04.
@@ -8,7 +8,7 @@
 import Foundation
 import RealmSwift
 
-public struct DiarySearchTagEntity: BaseRealmEntity {
+public struct TrainingTagEntity: BaseRealmEntity {
     
     public let id: UUID
     public let tagName: String
@@ -21,19 +21,19 @@ public struct DiarySearchTagEntity: BaseRealmEntity {
         self.tagName = tagName
     }
     
-    public init(realmObject: DiarySearchTagRealmObject) {
+    public init(realmObject: TrainingTagRealmObject) {
         
         id = realmObject.id
         tagName = realmObject.tagName
     }
     
-    public func toRealmObject() -> DiarySearchTagRealmObject {
+    public func toRealmObject() -> TrainingTagRealmObject {
         
-        return DiarySearchTagRealmObject(id: id, tagName: tagName)
+        return TrainingTagRealmObject(id: id, tagName: tagName)
     }
 }
 
-public class DiarySearchTagRealmObject: Object {
+public class TrainingTagRealmObject: Object {
     
     @Persisted(primaryKey: true) var id: UUID
     @Persisted var tagName: String

--- a/Macho/MachoFramework/Sources/RealmHelper/Entities/TrainingTypeEntity.swift
+++ b/Macho/MachoFramework/Sources/RealmHelper/Entities/TrainingTypeEntity.swift
@@ -1,0 +1,49 @@
+//
+//  TrainingTypeEntity.swift
+//
+//  
+//  Created by Daiki Fujimori on 2024/08/16
+//  
+
+
+import Foundation
+import RealmSwift
+
+public struct TrainingTypeEntity: BaseRealmEntity {
+    
+    public let id: UUID
+    public let name: String
+    
+    public static let executor = RealmObserverExecutor<Self>()
+    
+    public init(id: UUID, name: String) {
+        
+        self.id = id
+        self.name = name
+    }
+    
+    public init(realmObject: TrainingTypeRealmObject) {
+        
+        id = realmObject.id
+        name = realmObject.name
+    }
+    
+    public func toRealmObject() -> TrainingTypeRealmObject {
+        
+        return TrainingTypeRealmObject(id: id, name: name)
+    }
+}
+
+public class TrainingTypeRealmObject: Object {
+    
+    @Persisted(primaryKey: true) var id: UUID
+    @Persisted var name: String
+    
+    convenience init(id: UUID, name: String) {
+        
+        self.init()
+        
+        self.id = id
+        self.name = name
+    }
+}


### PR DESCRIPTION
## 関連Issue
- 関連Issue: #38 

## 概要
タグ、目標、トレーニング種目のEntity追加

## 変更点
- `DiaryEntity`, `TrainingGoalEntity`, `TrainingTypeEntity`の追加
- `DiarySearchTagEntity` -> `TrainingTagEntity`にリネーム

## 影響範囲
RealmObject

## 動作確認
- ビルドができること（ローカル環境にて確認）
