### PR TITLE
[AD1.0] 日記一覧画面の作成_TCA1.6から1.12へのマイグレーション対応

### DIFF
--- a/Macho/Macho.xcworkspace/contents.xcworkspacedata
+++ b/Macho/Macho.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,7 @@
    <FileRef
       location = "group:Macho.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:MachoFramework/MachoFramework.xctestplan">
+   </FileRef>
 </Workspace>

--- a/Macho/Macho.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Macho/Macho.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "71344dd930fde41e8f3adafe260adcbb2fc2a3dc",
-        "version" : "1.5.4"
+        "revision" : "642e6aab8e03e5f992d9c83e38c5be98cfad5078",
+        "version" : "1.5.5"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "3581e280bf0d90c3fb9236fb23e75a5d8c46b533",
-        "version" : "1.0.4"
+        "revision" : "b9b24b69e2adda099a1fa381cda1eeec272d5b53",
+        "version" : "1.0.5"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
-        "version" : "1.1.2"
+        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
+        "version" : "1.1.3"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "aec6a73f5c1dc1f1be4f61888094b95cf995d973",
-        "version" : "1.3.2"
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "cc26d06125dbc913c6d9e8a905a5db0b994509e0",
-        "version" : "1.3.5"
+        "revision" : "3ef38bb702a1a2f39c7e19fc0578403b8ee52b17",
+        "version" : "1.3.9"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "1552c8f722ac256cc0b8daaf1a7073217d4fcdfb",
-        "version" : "1.3.4"
+        "revision" : "bc67aa8e461351c97282c2419153757a446ae1c9",
+        "version" : "1.3.5"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "fc91d591ebba1f90d65028ccb65c861e5979e898",
-        "version" : "1.5.4"
+        "revision" : "e628806aeaa9efe25c1abcd97931a7c498fab281",
+        "version" : "1.5.5"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
-        "version" : "1.2.2"
+        "revision" : "96beb108a57f24c8476ae1f309239270772b2940",
+        "version" : "1.2.5"
       }
     }
   ],

--- a/Macho/MachoFramework/.swiftpm/xcode/xcshareddata/xcschemes/MachoFramework.xcscheme
+++ b/Macho/MachoFramework/.swiftpm/xcode/xcshareddata/xcschemes/MachoFramework.xcscheme
@@ -27,8 +27,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:MachoFramework.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Macho/MachoFramework/MachoFramework.xctestplan
+++ b/Macho/MachoFramework/MachoFramework.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "9D6E531E-8F33-403D-8FA9-8874FCCD66EC",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "MachoFrameworkTests",
+        "name" : "MachoFrameworkTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Macho/MachoFramework/Sources/MachoView/Common/Extensions/DateFormat_Date+Extension.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Common/Extensions/DateFormat_Date+Extension.swift
@@ -53,7 +53,7 @@ extension Date {
         /// yyyy/MM/dd(ex. 2000:01:01)
         case basic
         /// yyyy年MM月dd日(ex. 2000年01月01日)
-        case jp
+        case jpGregorian
         
         fileprivate func getFormatString(omissionTens: Bool) -> String {
             
@@ -62,7 +62,7 @@ extension Date {
             case .basic:
                 return omissionTens ? "yyyy/M/d" : "yyyy/MM/dd"
                 
-            case .jp:
+            case .jpGregorian:
                 return omissionTens ? "yyyy年M月d日" : "yyyy年MM月dd日"
             }
         }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/DiaryListView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/DiaryListView.swift
@@ -67,10 +67,6 @@ struct DiaryListView: View {
         }
         .alert(store: store.scope(state: \.$alert, action: \.alert))
         .transaction { $0.disablesAnimations = false }
-//        .fullScreenCover(store: $store.scope(state: \.destination, action: \.destination)) {
-//            getModalDestination($0)
-//                .presentationBackground(.clear)
-//        }
         .fullScreenCover(item: $store.scope(state: \.destination, action: \.destination)) {
             getModalDestination($0)
                 .presentationBackground(.clear)

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/DiaryListView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/DiaryListView.swift
@@ -14,7 +14,7 @@ struct DiaryListView: View {
     
     // MARK: - TCA store property
     
-    private var store: StoreOf<DiaryListFeature>
+    @Bindable private var store: StoreOf<DiaryListFeature>
     
     // MARK: - initialize method
     
@@ -53,7 +53,7 @@ struct DiaryListView: View {
     // MARK: - view property
     
     var body: some View {
-        NavigationStackStore(store.scope(state: \.path, action: \.path)) {
+        NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
             createMainView()
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
@@ -67,8 +67,12 @@ struct DiaryListView: View {
         }
         .alert(store: store.scope(state: \.$alert, action: \.alert))
         .transaction { $0.disablesAnimations = false }
-        .fullScreenCover(store: store.scope(state: \.$filterView, action: \.filterView)) {
-            DiaryListFilterView(store: $0)
+//        .fullScreenCover(store: $store.scope(state: \.destination, action: \.destination)) {
+//            getModalDestination($0)
+//                .presentationBackground(.clear)
+//        }
+        .fullScreenCover(item: $store.scope(state: \.destination, action: \.destination)) {
+            getModalDestination($0)
                 .presentationBackground(.clear)
         }
         .transaction { $0.disablesAnimations = true }
@@ -81,37 +85,35 @@ private extension DiaryListView {
     
     func createMainView() -> some View {
         GeometryReader { geometry in
-            WithViewStore(store, observe: \.viewState) { viewStore in
-                ZStack(alignment: .top) {
-                    VStack(spacing: .zero) {
-                        if !viewStore.isScrolling {
-                            createControlSection(viewStore: viewStore)
-                        }
-                        if viewStore.hasDiaryItems {
-                            createListSection(viewStore: viewStore)
-                        }
-                        else {
-                            createEmptyListView()
-                        }
-                        Spacer()
+            ZStack(alignment: .top) {
+                VStack(spacing: .zero) {
+                    if !store.viewState.isScrolling {
+                        createControlSection()
                     }
-                    if viewStore.isScrolling {
-                        createControlHeaderView(viewStore: viewStore)
+                    if store.viewState.hasDiaryItems {
+                        createListSection()
                     }
+                    else {
+                        createEmptyListView()
+                    }
+                    Spacer()
                 }
-                .toolbar(viewStore.isScrolling ? .hidden : .visible, for: .navigationBar)
-                .onAppear {
-                    viewStore.send(.onAppearView)
+                if store.viewState.isScrolling {
+                    createControlHeaderView()
                 }
+            }
+            .toolbar(store.viewState.isScrolling ? .hidden : .visible, for: .navigationBar)
+            .onAppear {
+                store.send(.onAppearView)
             }
             .frame(width: geometry.size.width,
                    height: geometry.size.height)
         }
     }
     
-    func createControlSection(viewStore: ViewStore<DiaryListFeature.State.ViewState, DiaryListFeature.Action>) -> some View {
+    func createControlSection() -> some View {
         VStack {
-            createControlHeaderView(viewStore: viewStore)
+            createControlHeaderView()
             Spacer()
                 .frame(height: controlSectionContentsPaddingBottom)
             Divider()
@@ -120,7 +122,7 @@ private extension DiaryListView {
         .background(Color(asset: CustomColor.appPrimaryBackgroundColor))
     }
     
-    func createListSection(viewStore: ViewStore<DiaryListFeature.State.ViewState, DiaryListFeature.Action>) -> some View {
+    func createListSection() -> some View {
         TrackableList(store: store.scope(state: \.trackableList, action: \.trackableList)) {
             ForEachStore(store.scope(state: \.diaries,
                                      action: \.diaries)) { store in
@@ -140,19 +142,19 @@ private extension DiaryListView {
             .multilineTextAlignment(.center)
     }
     
-    func createControlHeaderView(viewStore: ViewStore<DiaryListFeature.State.ViewState, DiaryListFeature.Action>) -> some View {
+    func createControlHeaderView() -> some View {
         HStack(spacing: .zero) {
             createFilterButton {
-                viewStore.send(.tappedFilterButton)
+                store.send(.tappedFilterButton)
             }
             Spacer()
             createGraphButton {
-                viewStore.send(.tappedGraphButton)
+                store.send(.tappedGraphButton)
             }
             Spacer()
                 .frame(width: graphButtonPaddingTrailing)
             createNewDiaryButton {
-                viewStore.send(.tappedCreateNewDiaryButton)
+                store.send(.tappedCreateNewDiaryButton)
             }
         }
         .padding(.horizontal, controlSectionPaddingHorizontal)
@@ -199,27 +201,38 @@ private extension DiaryListView {
 
 private extension DiaryListView {
     
-    func getNavigationDestination(_ store: Store<DiaryListFeature.Path.State, DiaryListFeature.Path.Action>) -> some View {
+    func getNavigationDestination(_ store: Store<DiaryListFeature.Path.State,
+                                  DiaryListFeature.Path.Action>) -> some View {
         
-        switch store.withState({ $0 }) {
+        switch store.case {
             
-            // TODO: 実装出来次第正しい画面に変更する
-        case .editScreen:
-            return IfLetStore(store.scope(state: \.editScreen, action: \.editScreen)) {
-                AddContactView(store: $0)
-            }
-        case .createScreen:
-            return IfLetStore(store.scope(state: \.createScreen, action: \.createScreen)) {
-                AddContactView(store: $0)
-            }
-        case .graphScreen:
-            return IfLetStore(store.scope(state: \.graphScreen, action: \.graphScreen)) {
-                AddContactView(store: $0)
-            }
-        case .detailScreen:
-            return IfLetStore(store.scope(state: \.detailScreen, action: \.detailScreen)) {
-                AddContactView(store: $0)
-            }
+        // TODO: 実装出来次第正しい画面に変更する
+        case .editScreen(let editScreenStore):
+            AddContactView(store: editScreenStore)
+            
+        case .createScreen(let createScreenStore):
+            AddContactView(store: createScreenStore)
+            
+        case .graphScreen(let graphScreenStore):
+            AddContactView(store: graphScreenStore)
+            
+        case .detailScreen(let detailScreenStore):
+            AddContactView(store: detailScreenStore)
+        }
+    }
+}
+
+// MARK: - Modal Presentation Route Definition
+
+private extension DiaryListView {
+    
+    func getModalDestination(_ store: Store<DiaryListFeature.Destination.State,
+                             DiaryListFeature.Destination.Action>) -> some View {
+        
+        switch store.case {
+            
+        case .filterScreen(let filterScreenStore):
+            DiaryListFilterView(store: filterScreenStore)
         }
     }
 }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/Filter/DiaryListFilterFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/Filter/DiaryListFilterFeature.swift
@@ -19,15 +19,13 @@ struct DiaryListFilterFeature {
         
         var viewState = ViewState()
         
-        @ObservationStateIgnored
-        var currentFilters: IdentifiedArrayOf<DiaryListFilterItem> {
+        @ObservationStateIgnored var currentFilters: IdentifiedArrayOf<DiaryListFilterItem> {
             
             get { viewState.currentFilters }
             set { viewState.currentFilters = newValue }
         }
         
-        @ObservationStateIgnored
-        var selectableFilterValues: [DiaryListFilterTarget: [String]] {
+        @ObservationStateIgnored var selectableFilterValues: [DiaryListFilterTarget: [String]] {
             
             get { viewState.selectableFilterValues }
             set { viewState.selectableFilterValues = newValue }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/Filter/DiaryListFilterFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/Filter/DiaryListFilterFeature.swift
@@ -14,15 +14,19 @@ struct DiaryListFilterFeature {
     // フィルターテーブル監視のCancellable
     struct FilterObserveCancellable: Hashable {}
     
+    @ObservableState
     struct State: Equatable, Sendable {
         
         var viewState = ViewState()
+        
+        @ObservationStateIgnored
         var currentFilters: IdentifiedArrayOf<DiaryListFilterItem> {
             
             get { viewState.currentFilters }
             set { viewState.currentFilters = newValue }
         }
         
+        @ObservationStateIgnored
         var selectableFilterValues: [DiaryListFilterTarget: [String]] {
             
             get { viewState.selectableFilterValues }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/ViewParts/DiaryListItemFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/ViewParts/DiaryListItemFeature.swift
@@ -8,8 +8,10 @@
 import ComposableArchitecture
 import Foundation
 
-struct DiaryListItemFeature: Reducer, Sendable {
+@Reducer
+struct DiaryListItemFeature: Sendable {
     
+    @ObservableState
     struct State: Equatable, Identifiable, Sendable {
         
         init(id: UUID = UUID(), title: String, message: String, date: Date, isWin: Bool, trainingList: [String]) {

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/ViewParts/DiaryListItemView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/ViewParts/DiaryListItemView.swift
@@ -12,7 +12,7 @@ struct DiaryListItemView: View {
     
     // MARK: tca store property
     
-    private let store: StoreOf<DiaryListItemFeature>
+    @Bindable private var store: StoreOf<DiaryListItemFeature>
     
     // MARK: initialize method
     
@@ -41,26 +41,24 @@ struct DiaryListItemView: View {
     // MARK: view property
     
     var body: some View {
-        WithViewStore(store, observe: { $0 }) { viewStore in
-            Button(action: {
-                viewStore.send(.tappedDiaryItem)
-            }, label: {
-                createDiaryItemContent(viewStore: viewStore)
-            })
-            .foregroundStyle(Color(asset: CustomColor.appPrimaryTextColor))
-            .background(Color(asset: CustomColor.appPrimaryBackgroundColor))
-            .addSwipeAction {
-                SwipeAction(tint: Color(asset: CustomColor.deleteSwipeBackgroundColor),
-                            icon: Image(systemName: "trash.fill")) {
-                    viewStore.send(.deleteItemSwipeAction)
-                }
-                SwipeAction(tint: Color(asset: CustomColor.editSwipeBackgroundColor),
-                            icon: Image(systemName: "pencil")) {
-                    viewStore.send(.editItemSwipeAction)
-                }
+        Button(action: {
+            store.send(.tappedDiaryItem)
+        }, label: {
+            createDiaryItemContent()
+        })
+        .foregroundStyle(Color(asset: CustomColor.appPrimaryTextColor))
+        .background(Color(asset: CustomColor.appPrimaryBackgroundColor))
+        .addSwipeAction {
+            SwipeAction(tint: Color(asset: CustomColor.deleteSwipeBackgroundColor),
+                        icon: Image(systemName: "trash.fill")) {
+                store.send(.deleteItemSwipeAction)
             }
-            .accessibilityHidden(true)
+            SwipeAction(tint: Color(asset: CustomColor.editSwipeBackgroundColor),
+                        icon: Image(systemName: "pencil")) {
+                store.send(.editItemSwipeAction)
+            }
         }
+        .accessibilityHidden(true)
     }
 }
 
@@ -68,19 +66,19 @@ struct DiaryListItemView: View {
 
 private extension DiaryListItemView {
     
-    func createDiaryItemContent(viewStore: ViewStore<DiaryListItemFeature.State, DiaryListItemFeature.Action>) -> some View {
+    func createDiaryItemContent() -> some View {
         VStack {
             HStack(spacing: .zero) {
-                createWinLoseIcon(isWin: viewStore.isWin)
+                createWinLoseIcon(isWin: store.isWin)
                 Spacer()
                     .frame(width: winLoseLabelTrailingPadding)
                 VStack(spacing: .zero) {
-                    createTopContents(title: viewStore.title,
-                                      date: viewStore.date.toString(.init(date: .jp),
-                                                                    isOmissionTens: true))
+                    createTopContents(title: store.title,
+                                      date: store.date.toString(.init(date: .jpGregorian),
+                                                                isOmissionTens: true))
                     Spacer()
                         .frame(height: titlePaddingBottom)
-                    createMessageContent(message: viewStore.message)
+                    createMessageContent(message: store.message)
                 }
             }
             .padding(.top, baseTopPadding)

--- a/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/AddContact/AddContactFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/AddContact/AddContactFeature.swift
@@ -39,7 +39,7 @@ struct AddContactFeature {
             switch action {
                 
             case .cancelButtonTapped:
-                return .run { _ in await self.dismiss() }
+                return .run { _ in await dismiss() }
                 
             case .delegate:
                 return .none
@@ -48,7 +48,7 @@ struct AddContactFeature {
                 return .run { [contact = state.contact] send in
                     
                     await send(.delegate(.saveContact(contact)))
-                    await self.dismiss()
+                    await dismiss()
                 }
                 
             case let .setName(name):

--- a/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/AddContact/AddContactFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/AddContact/AddContactFeature.swift
@@ -8,12 +8,15 @@
 
 import ComposableArchitecture
 
-struct AddContactFeature: Reducer {
+@Reducer
+struct AddContactFeature {
     
+    @ObservableState
     struct State: Equatable {
         
         var contact: Contact
     }
+    
     enum Action: Equatable {
         
         case cancelButtonTapped
@@ -29,26 +32,29 @@ struct AddContactFeature: Reducer {
     
     @Dependency(\.dismiss) var dismiss
     
-    func reduce(into state: inout State, action: Action) -> Effect<Action> {
+    var body: some ReducerOf<Self> {
         
-        switch action {
+        Reduce { state, action in
             
-        case .cancelButtonTapped:
-            return .run { _ in await dismiss() }
-            
-        case .delegate:
-            return .none
-            
-        case .saveButtonTapped:
-            return .run { [contact = state.contact] send in
+            switch action {
                 
-                await send(.delegate(.saveContact(contact)))
-                await dismiss()
+            case .cancelButtonTapped:
+                return .run { _ in await self.dismiss() }
+                
+            case .delegate:
+                return .none
+                
+            case .saveButtonTapped:
+                return .run { [contact = state.contact] send in
+                    
+                    await send(.delegate(.saveContact(contact)))
+                    await self.dismiss()
+                }
+                
+            case let .setName(name):
+                state.contact.name = name
+                return .none
             }
-            
-        case let .setName(name):
-            state.contact.name = name
-            return .none
         }
     }
 }

--- a/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/AddContact/AddContactView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/AddContact/AddContactView.swift
@@ -32,12 +32,10 @@ struct AddContactView: View {
 
 #Preview {
     NavigationStack {
-        AddContactView(store: Store(initialState: AddContactFeature.State(
-            contact: Contact(
-                id: UUID(),
-                name: "Blob"))) {
-                    
-                    AddContactFeature()
-                })
+        AddContactView(store: Store(initialState: AddContactFeature.State(contact: Contact(id: UUID(),
+                                                                                           name: "Blob"))) {
+            
+            AddContactFeature()
+        })
     }
 }

--- a/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/AddContact/AddContactView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/AddContact/AddContactView.swift
@@ -1,9 +1,9 @@
 //
 //  AddContactView.swift
 //  Macho
-//  
+//
 //  Created by Daiki Fujimori on 2023/11/04
-//  
+//
 //
 
 import ComposableArchitecture
@@ -11,36 +11,33 @@ import SwiftUI
 
 struct AddContactView: View {
     
-    let store: StoreOf<AddContactFeature>
+    @Bindable var store: StoreOf<AddContactFeature>
     
     var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
-            Form {
-                TextField("Name", text: viewStore.binding(get: \.contact.name, send: { .setName($0) }))
-                Button("Save") {
-                    viewStore.send(.saveButtonTapped)
-                }
+        Form {
+            TextField("Name", text: $store.contact.name.sending(\.setName))
+            Button("Save") {
+                store.send(.saveButtonTapped)
             }
-            .toolbar {
-                ToolbarItem {
-                    Button("Cancel") {
-                        viewStore.send(.cancelButtonTapped)
-                    }
+        }
+        .toolbar {
+            ToolbarItem {
+                Button("Cancel") {
+                    store.send(.cancelButtonTapped)
                 }
             }
         }
     }
 }
 
-struct AddContactPreviews: PreviewProvider {
-    
-    static var previews: some View {
-        NavigationStack {
-            AddContactView(store: Store(initialState: AddContactFeature.State(
-                contact: Contact(id: UUID(), name: "Blob"))) {
-                        
-                AddContactFeature()
-            })
-        }
+#Preview {
+    NavigationStack {
+        AddContactView(store: Store(initialState: AddContactFeature.State(
+            contact: Contact(
+                id: UUID(),
+                name: "Blob"))) {
+                    
+                    AddContactFeature()
+                })
     }
 }

--- a/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/ContactDetail/ContactDetailFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/ContactDetail/ContactDetailFeature.swift
@@ -8,11 +8,13 @@
 
 import ComposableArchitecture
 
-struct ContactDetailFeature: Reducer {
+@Reducer
+struct ContactDetailFeature {
     
+    @ObservableState
     struct State: Equatable {
         
-        @PresentationState var alert: AlertState<Alert>?
+        @Presents var alert: AlertState<Action.Alert>?
         let contact: Contact
     }
     
@@ -21,11 +23,11 @@ struct ContactDetailFeature: Reducer {
         case alert(PresentationAction<Alert>)
         case delegate(Delegate)
         case deleteButtonTapped
-    }
-    
-    enum Alert {
         
-        case confirmDeletion
+        enum Alert {
+            
+            case confirmDeletion
+        }
     }
     
     enum Delegate {
@@ -58,10 +60,11 @@ struct ContactDetailFeature: Reducer {
                 return .none
             }
         }
+        .ifLet(\.$alert, action: \.alert)
     }
 }
 
-extension AlertState where Action == ContactDetailFeature.Alert {
+extension AlertState where Action == ContactDetailFeature.Action.Alert {
     
     static let confirmDeletion = Self {
         

--- a/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/ContactDetail/ContactDetailView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Contacts/ContactDetail/ContactDetailView.swift
@@ -11,18 +11,16 @@ import SwiftUI
 
 struct ContactDetailView: View {
     
-    let store: StoreOf<ContactDetailFeature>
+    @Bindable var store: StoreOf<ContactDetailFeature>
     
     var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
-            Form {
-                Button("Delete") {
-                    viewStore.send(.deleteButtonTapped)
-                }
+        Form {
+            Button("Delete") {
+                store.send(.deleteButtonTapped)
             }
-            .navigationBarTitle(Text(viewStore.contact.name))
         }
-        .alert(store: self.store.scope(state: \.$alert, action: { .alert($0) }))
+        .navigationBarTitle(Text(store.contact.name))
+        .alert($store.scope(state: \.alert, action: \.alert))
     }
 }
 

--- a/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Counter/CounterFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Counter/CounterFeature.swift
@@ -1,18 +1,19 @@
 //
 //  CounterFeature.swift
 //  Macho
-//  
+//
 //  Created by Daiki Fujimori on 2023/10/28
-//  
+//
 //
 
 import ComposableArchitecture
-import Foundation
 
-struct CounterFeature: Reducer {
+@Reducer
+struct CounterFeature {
     
     // MARK: State
     
+    @ObservableState
     struct State: Equatable {
         
         var count = 0
@@ -41,10 +42,10 @@ struct CounterFeature: Reducer {
     // MARK: - body
     
     enum CancelID { case timer }
-
-      @Dependency(\.continuousClock) var clock
-      @Dependency(\.numberFact) var numberFact
-
+    
+    @Dependency(\.continuousClock) var clock
+    @Dependency(\.numberFact) var numberFact
+    
     var body: some ReducerOf<Self> {
         
         Reduce { state, action in

--- a/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Counter/CounterView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/TCASample/Counter/CounterView.swift
@@ -13,58 +13,55 @@ struct CounterView: View {
     
     // MARK: - Store
     
-    let store: StoreOf<CounterFeature>
+    @Bindable var store: StoreOf<CounterFeature>
     
     // MARK: - body
     
     var body: some View {
-        // Stateを監視するため、WithViewStoreでラップする.
-        WithViewStore(store, observe: { $0 }) { viewStore in
-            VStack {
-                Text("\(viewStore.count)")
-                    .font(.largeTitle)
-                    .padding()
-                    .background(Color.black.opacity(0.1))
-                    .cornerRadius(10)
-                HStack {
-                    Button("-") {
-                        // アクションをsend
-                        viewStore.send(.decrementButtonTapped)
-                    }
-                    .font(.largeTitle)
-                    .padding()
-                    .background(Color.black.opacity(0.1))
-                    .cornerRadius(10)
+        VStack {
+            Text("\(store.count)")
+                .font(.largeTitle)
+                .padding()
+                .background(Color.black.opacity(0.1))
+                .cornerRadius(10)
+            HStack {
+                Button("-") {
+                    // アクションをsend
+                    store.send(.decrementButtonTapped)
+                }
+                .font(.largeTitle)
+                .padding()
+                .background(Color.black.opacity(0.1))
+                .cornerRadius(10)
+                
+                Button("+") {
+                    // アクションをsend
+                    store.send(.incrementButtonTapped)
+                }
+                .font(.largeTitle)
+                .padding()
+                .background(Color.black.opacity(0.1))
+                .cornerRadius(10)
+                
+                Button("Fact") {
+                    // アクションをsend
+                    store.send(.factButtonTapped)
+                }
+                .font(.largeTitle)
+                .padding()
+                .background(Color.black.opacity(0.1))
+                .cornerRadius(10)
+                
+                if store.isLoading {
                     
-                    Button("+") {
-                        // アクションをsend
-                        viewStore.send(.incrementButtonTapped)
-                    }
-                    .font(.largeTitle)
-                    .padding()
-                    .background(Color.black.opacity(0.1))
-                    .cornerRadius(10)
+                  ProgressView()
+                }
+                else if let fact = store.fact {
                     
-                    Button("Fact") {
-                        // アクションをsend
-                        viewStore.send(.factButtonTapped)
-                    }
+                  Text(fact)
                     .font(.largeTitle)
+                    .multilineTextAlignment(.center)
                     .padding()
-                    .background(Color.black.opacity(0.1))
-                    .cornerRadius(10)
-                    
-                    if viewStore.isLoading {
-                        
-                      ProgressView()
-                    }
-                    else if let fact = viewStore.fact {
-                        
-                      Text(fact)
-                        .font(.largeTitle)
-                        .multilineTextAlignment(.center)
-                        .padding()
-                    }
                 }
             }
         }

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryList/DiaryListViewTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryList/DiaryListViewTest.swift
@@ -495,26 +495,26 @@ final class DiaryListViewTests: XCTestCase {
         await store.send(.tappedFilterButton) {
             
             // フィルター画面を宛先に追加
-            $0.filterView = DiaryListFilterFeature.State()
+            $0.destination = .filterScreen(DiaryListFilterFeature.State())
         }
         
         // フィルター画面のダイアログ外の領域タップ
-        await store.send(.filterView(.presented(.tappedOutsideArea))) {
+        await store.send(.destination(.presented(.filterScreen(.tappedOutsideArea)))) {
             
-            $0.filterView = nil
+            $0.destination = nil
         }
         
         // フィルターボタンを押下
         await store.send(.tappedFilterButton) {
             
             // フィルター画面を宛先に追加
-            $0.filterView = DiaryListFilterFeature.State()
+            $0.destination = .filterScreen(DiaryListFilterFeature.State())
         }
         
         // フィルター画面の閉じるボタンタップ
-        await store.send(.filterView(.presented(.tappedCloseButton))) {
+        await store.send(.destination(.presented(.filterScreen(.tappedCloseButton)))) {
             
-            $0.filterView = nil
+            $0.destination = nil
         }
     }
 }

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryList/DiaryListViewTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryList/DiaryListViewTest.swift
@@ -78,8 +78,8 @@ final class DiaryListViewTests: XCTestCase {
         
         // スクロール画面の表示サイズの高さが800px、スクロールできるサイズの高さが1000pxの状態
         let trackableListState = TrackableListFeature.State(offset: 0,
-                                                            containerSize: CGSize(width: 400, height: 800),
-                                                            contentSize: CGSize(width: 400, height: 1000))
+                                                            listSizeInfo: .init(containerSize: CGSize(width: 400, height: 800),
+                                                                                contentSize: CGSize(width: 400, height: 1000)))
         
         let viewState = DiaryListFeature.State.ViewState(hasDiaryItems: true)
         


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #22 

## 概要
TCAのバージョンアップに伴い1.6の書き方でdeprecatedが発生している箇所を推奨されている記法に修正。
またコードの簡略化できるところも修正

## 変更点

- 以下画面をTCAの1.12の記法に修正
  - 日記リスト画面
  - 日記リストフィルター画面
  - Contact画面（サンプル画面）
  - Counter画面サンプル画面）

## 影響範囲
- 以下画面
  - 日記リスト画面
  - 日記リストフィルター画面
  - Contact画面（サンプル画面）
  - Counter画面サンプル画面）

## 動作確認

- Previewにて動作が変わっていないことを確認
- UTが全て通ることを確認
