### PR TITLE
[AD1.0] 日記作成画面でキーボード表示中にキーボード領域外をタップするとキーボードを閉じるようにする

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -39,7 +39,7 @@ struct DiaryCreationFeature: Sendable {
         var goals: [Goal] = []
         var isEnableStartButton = false
         var animationsRunning = false
-        var isFocusedTextField: DiaryCreationTextFieldFocus?
+        var textFieldFocusState: DiaryCreationTextFieldFocus?
         
         @Presents var destination: Destination.State?
     }
@@ -177,11 +177,11 @@ struct DiaryCreationFeature: Sendable {
                 return .none
                 
             case .didChangeFocusState(let newState):
-                state.isFocusedTextField = newState
+                state.textFieldFocusState = newState
                 return .none
                 
             case .tappedOutsideOfKeyboard:
-                state.isFocusedTextField = nil
+                state.textFieldFocusState = nil
                 return .none
                 
             case .destination(.presented(.addGoal(.delegate(.saveGoal(let goal))))):

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -8,21 +8,6 @@
 import ComposableArchitecture
 import SwiftUI
 
-struct Tag: Equatable, Identifiable {
-    
-    var id: UUID { entity.id }
-    let entity: TrainingTagData
-    var isSelected = false
-}
-
-struct Goal: Equatable, Identifiable {
-    
-    let id: UUID
-    var trainingType: TrainingTypeData
-    var numberOfSets: Int
-    var setCount: Int
-}
-
 @Reducer
 struct DiaryCreationFeature: Sendable {
     

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -39,6 +39,7 @@ struct DiaryCreationFeature: Sendable {
         var goals: [Goal] = []
         var isEnableStartButton = false
         var animationsRunning = false
+        var isFocusedTextField: DiaryCreationTextFieldFocus?
         
         @Presents var destination: Destination.State?
     }
@@ -61,6 +62,8 @@ struct DiaryCreationFeature: Sendable {
         case tappedAddingGoalButton
         case deletedGoal(Goal)
         case editingGoal(Goal)
+        case didChangeFocusState(DiaryCreationTextFieldFocus?)
+        case tappedOutsideOfKeyboard
     }
     
     @Dependency(\.trainingTagApi) var trainingTagApi
@@ -171,6 +174,14 @@ struct DiaryCreationFeature: Sendable {
                                                                   numberOfSets: goal.numberOfSets,
                                                                   setCount: goal.setCount,
                                                                   isEnableSaveButton: true))
+                return .none
+                
+            case .didChangeFocusState(let newState):
+                state.isFocusedTextField = newState
+                return .none
+                
+            case .tappedOutsideOfKeyboard:
+                state.isFocusedTextField = nil
                 return .none
                 
             case .destination(.presented(.addGoal(.delegate(.saveGoal(let goal))))):

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -14,6 +14,7 @@ struct DiaryCreationView: View {
     
     @Bindable private var store: StoreOf<DiaryCreationFeature>
     @State private var animationsRunning = false
+    @FocusState private var isFocused: DiaryCreationTextFieldFocus?
     
     // MARK: - initialize
     
@@ -53,8 +54,19 @@ struct DiaryCreationView: View {
     
     var body: some View {
         GeometryReader { geometry in
-            createView(parentSize: geometry.size)
-                .frame(maxWidth: geometry.size.width, minHeight: geometry.size.height)
+            ZStack {
+                createView(parentSize: geometry.size)
+                    .frame(maxWidth: geometry.size.width, minHeight: geometry.size.height)
+                if isFocused != nil {
+                    Color(asset: CustomColor.dialogBackgroundColor)
+                        .opacity(0.1)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            store.send(.tappedOutsideOfKeyboard)
+                        }
+                }
+            }
         }
         .navigationTitle("Create Diary")
         .navigationBarTitleDisplayMode(.inline)
@@ -76,6 +88,8 @@ struct DiaryCreationView: View {
             
             store.send(.onAppear)
         }
+        .synchronize($store.isFocusedTextField.sending(\.didChangeFocusState),
+                     $isFocused)
     }
 }
 
@@ -115,6 +129,7 @@ private extension DiaryCreationView {
         VStack(alignment: .leading) {
             Text("title")
             TextField("\(formatter.string(from: Date()))", text: $store.titleText.sending(\.titleTextChange))
+                .focused($isFocused, equals: .title)
                 .padding(8)
                 .overlay(RoundedRectangle(cornerRadius: textEditorCornerRadius)
                     .stroke(Color(uiColor: .systemGray2), lineWidth: lineWidth))
@@ -127,6 +142,7 @@ private extension DiaryCreationView {
             Text("message")
             ZStack(alignment: .topLeading) {
                 TextEditor(text: $store.messageText.sending(\.messageTextChange))
+                    .focused($isFocused, equals: .message)
                     .padding(textEditorPadding)
                     .overlay(RoundedRectangle(cornerRadius: textEditorCornerRadius)
                         .stroke(Color(uiColor: .systemGray2), lineWidth: lineWidth))

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -14,7 +14,7 @@ struct DiaryCreationView: View {
     
     @Bindable private var store: StoreOf<DiaryCreationFeature>
     @State private var animationsRunning = false
-    @FocusState private var isFocused: DiaryCreationTextFieldFocus?
+    @FocusState private var textFieldFocusState: DiaryCreationTextFieldFocus?
     
     // MARK: - initialize
     
@@ -57,7 +57,7 @@ struct DiaryCreationView: View {
             ZStack {
                 createView(parentSize: geometry.size)
                     .frame(maxWidth: geometry.size.width, minHeight: geometry.size.height)
-                if isFocused != nil {
+                if textFieldFocusState != nil {
                     Color.clear.contentShape(Rectangle())
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .ignoresSafeArea()
@@ -87,8 +87,8 @@ struct DiaryCreationView: View {
             
             store.send(.onAppear)
         }
-        .synchronize($store.isFocusedTextField.sending(\.didChangeFocusState),
-                     $isFocused)
+        .synchronize($store.textFieldFocusState.sending(\.didChangeFocusState),
+                     $textFieldFocusState)
     }
 }
 
@@ -128,7 +128,7 @@ private extension DiaryCreationView {
         VStack(alignment: .leading) {
             Text("title")
             TextField("\(formatter.string(from: Date()))", text: $store.titleText.sending(\.titleTextChange))
-                .focused($isFocused, equals: .title)
+                .focused($textFieldFocusState, equals: .title)
                 .padding(8)
                 .overlay(RoundedRectangle(cornerRadius: textEditorCornerRadius)
                     .stroke(Color(uiColor: .systemGray2), lineWidth: lineWidth))
@@ -141,7 +141,7 @@ private extension DiaryCreationView {
             Text("message")
             ZStack(alignment: .topLeading) {
                 TextEditor(text: $store.messageText.sending(\.messageTextChange))
-                    .focused($isFocused, equals: .message)
+                    .focused($textFieldFocusState, equals: .message)
                     .padding(textEditorPadding)
                     .overlay(RoundedRectangle(cornerRadius: textEditorCornerRadius)
                         .stroke(Color(uiColor: .systemGray2), lineWidth: lineWidth))

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -58,8 +58,7 @@ struct DiaryCreationView: View {
                 createView(parentSize: geometry.size)
                     .frame(maxWidth: geometry.size.width, minHeight: geometry.size.height)
                 if isFocused != nil {
-                    Color(asset: CustomColor.dialogBackgroundColor)
-                        .opacity(0.1)
+                    Color.clear.contentShape(Rectangle())
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .ignoresSafeArea()
                         .onTapGesture {

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/DiaryCreationTextFieldFocus.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/DiaryCreationTextFieldFocus.swift
@@ -1,0 +1,14 @@
+//
+//  MachoFramework
+//
+//  DiaryCreationTextFieldFocus.swift
+//
+//  Created by stotic-dev on 2025/03/09
+//  Copyright © Macho All rights reserved.
+//
+
+enum DiaryCreationTextFieldFocus {
+    
+    case title
+    case message
+}

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Goal.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Goal.swift
@@ -1,0 +1,18 @@
+//
+//  MachoFramework
+//
+//  Goal.swift
+//
+//  Created by stotic-dev on 2025/03/09
+//  Copyright © Macho All rights reserved.
+//
+
+import Foundation
+
+struct Goal: Equatable, Identifiable {
+    
+    let id: UUID
+    var trainingType: TrainingTypeData
+    var numberOfSets: Int
+    var setCount: Int
+}

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Tag.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Tag.swift
@@ -1,0 +1,17 @@
+//
+//  MachoFramework
+//
+//  Tag.swift
+//
+//  Created by stotic-dev on 2025/03/09
+//  Copyright © Macho All rights reserved.
+//
+
+import Foundation
+
+struct Tag: Equatable, Identifiable {
+    
+    var id: UUID { entity.id }
+    let entity: TrainingTagData
+    var isSelected = false
+}

--- a/Macho/MachoFramework/Sources/MachoView/Views/ViewUtilities/ViewExtension/SyncFocusState.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/ViewUtilities/ViewExtension/SyncFocusState.swift
@@ -1,0 +1,27 @@
+//
+//  MachoFramework
+//
+//  SyncFocusState.swift
+//
+//  Created by stotic-dev on 2025/03/09
+//  Copyright © Macho All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+    
+    func synchronize<Value: Equatable>(
+        _ first: Binding<Value>,
+        _ second: FocusState<Value>.Binding
+    ) -> some View {
+        onChange(of: first.wrappedValue) { _, newValue in
+            
+            second.wrappedValue = newValue
+        }
+        .onChange(of: second.wrappedValue) { _, newValue in
+            
+            first.wrappedValue = newValue
+        }
+    }
+}

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/DiaryCreationViewTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/DiaryCreationViewTest.swift
@@ -1,0 +1,42 @@
+//
+//  MachoFramework
+//
+//  DiaryCreationViewTest.swift
+//
+//  Created by stotic-dev on 2025/03/09
+//  Copyright © Macho All rights reserved.
+//
+
+import ComposableArchitecture
+import Testing
+
+@testable import MachoView
+
+@MainActor
+struct DiaryCreationViewTest {
+
+    @Test
+    func キーボード表示中にキーボード領域外をタップするとキーボードを閉じる() async throws {
+        
+        let testStore = TestStore(initialState: .init(isFocusedTextField: .title),
+                                  reducer: { DiaryCreationFeature() })
+        
+        await testStore.send(.tappedOutsideOfKeyboard) {
+            
+            $0.isFocusedTextField = nil
+        }
+    }
+    
+    @Test
+    func テキストフィールドをタップした場合タップしたテキストフィールドにフォーカスする() async throws {
+        
+        let testStore = TestStore(initialState: .init(),
+                                  reducer: { DiaryCreationFeature() })
+        
+        await testStore.send(.didChangeFocusState(.title)) {
+            
+            $0.isFocusedTextField = .title
+        }
+    }
+
+}

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/DiaryCreationViewTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/DiaryCreationViewTest.swift
@@ -18,12 +18,12 @@ struct DiaryCreationViewTest {
     @Test
     func キーボード表示中にキーボード領域外をタップするとキーボードを閉じる() async throws {
         
-        let testStore = TestStore(initialState: .init(isFocusedTextField: .title),
+        let testStore = TestStore(initialState: .init(textFieldFocusState: .title),
                                   reducer: { DiaryCreationFeature() })
         
         await testStore.send(.tappedOutsideOfKeyboard) {
             
-            $0.isFocusedTextField = nil
+            $0.textFieldFocusState = nil
         }
     }
     
@@ -35,7 +35,7 @@ struct DiaryCreationViewTest {
         
         await testStore.send(.didChangeFocusState(.title)) {
             
-            $0.isFocusedTextField = .title
+            $0.textFieldFocusState = .title
         }
     }
 


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #70 

## 概要
日記作成画面でメッセージを入力するときに表示されるキーボードを閉じる方法がなかったので、以下仕様になるよう修正しました。

>以下仕様で実装修正する
>
>- 一行のテキストフィールドは以下を行うことで、キーボードが非表示になる
>   - returnを押下する
>   - キーボード外をタップする
>- 複数行のテキストフィールドは以下を行うことで、キーボードが非表示になる
>   - キーボード外をタップする

## 変更点

- 日記作成画面でテキストフィールドのキーボード表示中にキーボード領域外をタップすると、キーボードを閉じるように変更
- 日記作成画面のキーボード表示状態更新のテストケースを追加

## 影響範囲
日記作成画面

## 動作確認

- シミュレーターで、概要にて記載した仕様通りに動作していることを確認
https://github.com/user-attachments/assets/28e084a1-adb0-494b-8027-b0d7d8f8f6c3

- UTが全て通ること