### PR TITLE
[AD1.0] 日記作成画面で戻るボタン押下時に入力した日記情報が削除される旨の確認アラートを表示するようにする

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -27,6 +27,7 @@ struct DiaryCreationFeature: Sendable {
         var textFieldFocusState: DiaryCreationTextFieldFocus?
         
         @Presents var destination: Destination.State?
+        @Presents var alert: AlertState<Action.Alert>?
     }
     
     // MARK: - Action
@@ -49,6 +50,8 @@ struct DiaryCreationFeature: Sendable {
         case editingGoal(Goal)
         case didChangeFocusState(DiaryCreationTextFieldFocus?)
         case tappedOutsideOfKeyboard
+        case tappedNavigationBackButton
+        case alert(PresentationAction<Alert>)
     }
     
     @Dependency(\.trainingTagApi) var trainingTagApi
@@ -59,6 +62,7 @@ struct DiaryCreationFeature: Sendable {
     
     var body: some ReducerOf<Self> {
         
+        // swiftlint:disable:next closure_body_length
         Reduce { state, action in
             
             switch action {
@@ -169,6 +173,11 @@ struct DiaryCreationFeature: Sendable {
                 state.textFieldFocusState = nil
                 return .none
                 
+            case .tappedNavigationBackButton:
+                state.alert = .createAlertStateWithCancel(.confirmNoSavingDiary,
+                                                          firstButtonHandler: .tappedDismissAcceptButton)
+                return .none
+                
             case .destination(.presented(.addGoal(.delegate(.saveGoal(let goal))))):
                 guard let index = state.goals.firstIndex(where: { $0.trainingType == goal.trainingType }) else {
                     
@@ -180,11 +189,21 @@ struct DiaryCreationFeature: Sendable {
                 state.isEnableStartButton = isEnableStartButton(state: state)
                 return .none
                 
-            case .destination:
+            case .alert(.presented(.tappedDismissAcceptButton)):
+                return .concatenate(
+                    .cancel(id: TrainingTagsSubscriber()),
+                    .run { _ in
+                        
+                        await dismiss()
+                    }
+                )
+                
+            case .destination, .alert:
                 return .none
             }
         }
         .ifLet(\.$destination, action: \.destination)
+        .ifLet(\.$alert, action: \.alert)
     }
 }
 
@@ -271,5 +290,14 @@ extension DiaryCreationFeature {
             
             return lhs.id == rhs.id
         }
+    }
+}
+
+extension DiaryCreationFeature.Action {
+    
+    enum Alert {
+        
+        /// 前画面を戻ることを了承するボタンを押下
+        case tappedDismissAcceptButton
     }
 }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -70,12 +70,7 @@ struct DiaryCreationFeature: Sendable {
             case .onAppear:
                 logger.debug("onAppear")
                 return .concatenate(
-                    .publisher {
-                         
-                        return trainingTagApi.getTrainingTagPublisher()
-                            .receive(on: DispatchQueue.main)
-                            .map { .fetchedTags($0) }
-                    }.cancellable(id: TrainingTagsSubscriber()),
+                    addObserveTagEntity(),
                     fetchTags()
                 )
                 
@@ -110,8 +105,8 @@ struct DiaryCreationFeature: Sendable {
                     .run { [state] _ in
                         
                         await addDiary(state: state)
-                        await dismiss()
-                    }
+                    },
+                    popToPrev()
                 )
                 
             case .animateStartButton:
@@ -128,15 +123,7 @@ struct DiaryCreationFeature: Sendable {
             case .tappedTag(let tag):
                 withAnimation(.easeIn(duration: 0.15)) {
                     
-                    state.tags = state.tags.map {
-                        
-                        if $0.entity.id == tag.entity.id {
-                            
-                            return Tag(entity: $0.entity, isSelected: !$0.isSelected)
-                        }
-                        
-                        return $0
-                    }
+                    state.tags = updateTagSelectedState(target: tag, currentList: state.tags)
                 }
                 return .none
                 
@@ -190,13 +177,7 @@ struct DiaryCreationFeature: Sendable {
                 return .none
                 
             case .alert(.presented(.tappedDismissAcceptButton)):
-                return .concatenate(
-                    .cancel(id: TrainingTagsSubscriber()),
-                    .run { _ in
-                        
-                        await dismiss()
-                    }
-                )
+                return popToPrev()
                 
             case .destination, .alert:
                 return .none
@@ -253,14 +234,44 @@ private extension DiaryCreationFeature {
                          endTime: nil)
     }
     
-    func cancelChangesetObserve() -> Effect<Self.Action> {
+    func popToPrev() -> Effect<Self.Action> {
         
-        return .cancel(id: TrainingTagsSubscriber())
+        return .merge(
+            .cancel(id: TrainingTagsSubscriber()),
+            .run { _ in
+                
+                await dismiss()
+            }
+        )
     }
     
     func isEnableStartButton(state: State) -> Bool {
         
         return !(state.titleText.isEmpty || state.goals.isEmpty)
+    }
+    
+    func addObserveTagEntity() -> Effect<Self.Action> {
+        
+        return .publisher {
+             
+            return trainingTagApi.getTrainingTagPublisher()
+                .receive(on: DispatchQueue.main)
+                .map { .fetchedTags($0) }
+        }.cancellable(id: TrainingTagsSubscriber())
+    }
+    
+    func updateTagSelectedState(target: Tag, currentList: [Tag]) -> [Tag] {
+        
+        guard let targetIndex = currentList.firstIndex(where: { $0 == target }) else {
+            
+            return currentList
+        }
+        
+        var result = currentList
+        let currentTag = result[targetIndex]
+        result[targetIndex] = .init(entity: target.entity,
+                                    isSelected: !currentTag.isSelected)
+        return result
     }
 }
 
@@ -269,29 +280,14 @@ private extension DiaryCreationFeature {
 extension DiaryCreationFeature {
     
     @Reducer(state: .equatable, action: .equatable)
-    enum Destination: Equatable {
+    enum Destination {
         
         case addTag(AddTagFeature)
         case addGoal(AddGoalFeature)
-        
-        var id: Int {
-            
-            switch self {
-                
-            case .addTag:
-                return 0
-                
-            case .addGoal:
-                return 1
-            }
-        }
-        
-        static func == (lhs: DiaryCreationFeature.Destination, rhs: DiaryCreationFeature.Destination) -> Bool {
-            
-            return lhs.id == rhs.id
-        }
     }
 }
+
+// MARK: - extension (for alert)
 
 extension DiaryCreationFeature.Action {
     

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -59,6 +59,8 @@ struct DiaryCreationView: View {
                     .frame(maxWidth: geometry.size.width, minHeight: geometry.size.height)
                 if textFieldFocusState != nil {
                     Color.clear.contentShape(Rectangle())
+                        .accessibilityAddTraits(.isButton)
+                        .accessibilityLabel("キーボードを閉じる")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .ignoresSafeArea()
                         .onTapGesture {

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -67,6 +67,14 @@ struct DiaryCreationView: View {
                 }
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                NavigationButton(.back) {
+                    store.send(.tappedNavigationBackButton)
+                }
+            }
+        }
+        .navigationBarBackButtonHidden()
         .navigationTitle("Create Diary")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $store.scope(state: \.destination, action: \.destination)) { destination in
@@ -83,6 +91,7 @@ struct DiaryCreationView: View {
                 }
             }
         }
+        .alert(store: store.scope(state: \.$alert, action: \.alert))
         .onAppear {
             
             store.send(.onAppear)
@@ -309,10 +318,11 @@ private extension DiaryCreationView {
 // MARK: - preview
 
 #Preview {
-    DiaryCreationView(store: Store(initialState: DiaryCreationFeature.State()) {
-        
-        DiaryCreationFeature()
-    })
+    NavigationStack {
+        DiaryCreationView(store: Store(initialState: DiaryCreationFeature.State()) {
+            DiaryCreationFeature()
+        })
+    }
 }
 
 #Preview("タグあり(ひとつだけ)") {

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/DiaryListFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/DiaryListFeature.swift
@@ -69,7 +69,6 @@ struct DiaryListFeature: Sendable {
         /// アラートの表示
         case alert(PresentationAction<Alert>)
         /// モーダル遷移による画面表示
-//        case destination(PresentationAction<Destination.Action>)
         case destination(PresentationAction<PopUpFeature<DiaryListFilterFeature>.Action>)
         
         // MARK: Navigation Action

--- a/Macho/MachoFramework/Sources/MachoView/Views/ViewUtilities/Alert/AlertType.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/ViewUtilities/Alert/AlertType.swift
@@ -12,6 +12,7 @@ enum AlertType {
     case deleteDiaryItemConfirmAlert // 日記項目削除時の確認アラート
     case editDiaryItemConfirmAlert // 日記項目編集時の確認アラート
     case emptyDiaryItemAlert // 日記が一件も存在しない場合のアラート
+    case confirmNoSavingDiary // 日記が保存されないことを確認するアラート
 }
 
 // MARK: - アラートのタイトル
@@ -32,6 +33,9 @@ extension AlertType {
             return "まだ日記が一度も作成されていません。"
             + "\n"
             + "日記を作成してみましょう!"
+            
+        case .confirmNoSavingDiary:
+            return "作成画面から離れると、入力した内容は削除されてしまいますがよろしいですか？"
         }
     }
 }
@@ -46,7 +50,8 @@ extension AlertType {
             
         case .deleteDiaryItemConfirmAlert,
                 .editDiaryItemConfirmAlert,
-                .emptyDiaryItemAlert:
+                .emptyDiaryItemAlert,
+                .confirmNoSavingDiary:
             return nil
         }
     }
@@ -62,7 +67,8 @@ extension AlertType {
             
         case .deleteDiaryItemConfirmAlert,
                 .editDiaryItemConfirmAlert,
-                .emptyDiaryItemAlert:
+                .emptyDiaryItemAlert,
+                .confirmNoSavingDiary:
             return "OK"
         }
     }
@@ -78,7 +84,8 @@ extension AlertType {
             
         case .deleteDiaryItemConfirmAlert,
                 .editDiaryItemConfirmAlert,
-                .emptyDiaryItemAlert:
+                .emptyDiaryItemAlert,
+                .confirmNoSavingDiary:
             return nil
         }
     }

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/DiaryCreationViewTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/DiaryCreationViewTest.swift
@@ -39,4 +39,39 @@ struct DiaryCreationViewTest {
         }
     }
 
+    @Test
+    func 戻るボタンを押下すると入力情報が消えることを確認するアラートを表示する() async throws {
+        
+        let testStore = TestStore(initialState: .init(),
+                                  reducer: { DiaryCreationFeature() })
+        
+        await testStore.send(.tappedNavigationBackButton) {
+            
+            $0.alert = .createAlertStateWithCancel(.confirmNoSavingDiary,
+                                                   firstButtonHandler: .tappedDismissAcceptButton)
+        }
+    }
+    
+    @Test
+    func 入力情報が消えることを確認するアラートでOKボタン押下すると前画面に戻る() async throws {
+        
+        let dismissInvoke = LockIsolated(false)
+        let testStore = TestStore(initialState: .init(
+            alert: .createAlertStateWithCancel(
+                .confirmNoSavingDiary,
+                firstButtonHandler: .tappedDismissAcceptButton
+            )
+        ),
+                                  reducer: { DiaryCreationFeature() }) {
+            
+            $0.dismiss = .init { dismissInvoke.setValue(true) }
+        }
+        
+        await testStore.send(.alert(.presented(.tappedDismissAcceptButton))) {
+            
+            $0.alert = nil
+        }
+        
+        #expect(dismissInvoke.value)
+    }
 }


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #71 

## 概要
日記作成画面で戻るボタン押下時に入力した日記情報が削除される旨の確認アラートを表示するようにする

詳細な仕様は以下の通り
>- 日記作成画面で戻るボタンを押下した時、以下内容のアラートを表示する
>  - 「作成画面から離れると、入力した内容は削除されてしまいますがよろしいですか？」
>  - キャンセルボタン: 画面遷移はせず作成画面にとどまる
>  - OKボタン: 日記情報の保存は行わず、前画面に戻る

## 変更点

- 日記作成画面で戻るボタン押下時にアラートを表示するように修正
- 日記作成画面の戻るボタン押下時とアラートのボタン押下時のテストケースを追加
- 日記作成画面の警告が出ていた箇所の修正

## 影響範囲
日記作成画面

## 動作確認

- シミュレーターで概要に記載した仕様の通りに動作していることを確認
- シミュレーターで、日記作成画面にて日記が作成できることを確認
- UTが全て通ることを確認

https://github.com/user-attachments/assets/5545e783-5330-4059-8000-29b1f54ec186
