### PR TITLE
[AD1.0] タグの新規追加ができない問題の修正

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Dependencies/TrainingTagClient.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Dependencies/TrainingTagClient.swift
@@ -96,7 +96,7 @@ private extension TrainingTagClient {
     /// DBにタグを追加します.
     static func addTags(_ realm: RealmAccessible = RealmAccessor(), tag: TrainingTagData) async -> Bool {
         
-        guard await fetchAllTag(realm).contains(where: { $0.tagName == tag.tagName }) else {
+        if await fetchAllTag(realm).contains(where: { $0.tagName == tag.tagName }) {
             
             logger.error("same name already added.")
             return false

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/TestHelper/Mocks/RealmAccessorMock.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/TestHelper/Mocks/RealmAccessorMock.swift
@@ -12,13 +12,13 @@ import XCTest
 
 class RealmAccessorMock<Entity>: RealmAccessible where Entity: BaseRealmEntity {
     
-    private var fetchEntity: [Entity]
-    private var expectedInsertResult: ([Entity]) -> Bool
-    private var expectedUpdateResult: (Entity.Type, [String : Any]) -> Bool
-    private var expectedDeleteResult: () -> Bool
-    private var expectedDeleteAllResult: () -> Bool
-    private var expectedTruncateResult: () -> Bool
-    private var expectedNotification: AnyPublisher<[Entity], Never>
+    var fetchEntity: [Entity]
+    var expectedInsertResult: ([Entity]) -> Bool
+    var expectedUpdateResult: (Entity.Type, [String : Any]) -> Bool
+    var expectedDeleteResult: () -> Bool
+    var expectedDeleteAllResult: () -> Bool
+    var expectedTruncateResult: () -> Bool
+    var expectedNotification: AnyPublisher<[Entity], Never>
     
     private var cancellable: AnyCancellable?
     

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/AddTag/AddTagViewTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/AddTag/AddTagViewTest.swift
@@ -25,39 +25,32 @@ struct AddTagViewTest {
             TrainingTagData.fine
         ])
         
-        async let checkAddTag: () = confirmation { confirmation in
-            let result = await withCheckedContinuation { continuation in
-                mockRealm.expectedInsertResult = { actual in
+        await confirmation { confirmation in
+            mockRealm.expectedInsertResult = { actual in
+                
+                guard let target = try? #require(actual.first) else {
                     
-                    guard let target = try? #require(actual.first) else {
-                        
-                        continuation.resume(returning: false)
-                        return false
-                    }
-                    #expect(target.tagName == TrainingTagData.unfine.tagName)
-                    continuation.resume(returning: true)
-                    return true
+                    return false
                 }
+                #expect(target.tagName == TrainingTagData.unfine.tagName)
+                confirmation()
+                return true
             }
             
-            #expect(result)
-            confirmation()
-        }
-        
-        let testStore = TestStore(initialState: .init(
-            tagName: TrainingTagData.unfine.tagName,
-            isEnableSaveButton: true
-        ),
-                                  reducer: { AddTagFeature() }) {
+            let testStore = TestStore(initialState: .init(
+                tagName: TrainingTagData.unfine.tagName,
+                isEnableSaveButton: true
+            ),
+                                      reducer: { AddTagFeature() }) {
+                
+                $0.trainingTagApi = TrainingTagClient.createCustomValue(mockRealm)
+                $0.dismiss = .init { dismissInvoke.setValue(true) }
+            }
             
-            $0.trainingTagApi = TrainingTagClient.createCustomValue(mockRealm)
-            $0.dismiss = .init { dismissInvoke.setValue(true) }
+            await testStore.send(.saveButtonTapped)
+            
+            #expect(dismissInvoke.value)
         }
-        
-        await testStore.send(.saveButtonTapped)
-        
-        await checkAddTag
-        #expect(dismissInvoke.value)
     }
     
     @Test

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/AddTag/AddTagViewTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/AddTag/AddTagViewTest.swift
@@ -1,0 +1,89 @@
+//
+//  MachoFramework
+//
+//  AddTagViewTest.swift
+//
+//  Created by stotic-dev on 2025/03/09
+//  Copyright © Macho All rights reserved.
+//
+
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import MachoView
+
+@MainActor
+struct AddTagViewTest {
+
+    @Test
+    func タグ保存ボタン押下で入力しているタグ名のタグを登録する() async throws {
+        
+        let dismissInvoke = LockIsolated(false)
+        
+        let mockRealm = RealmAccessorMock(fetchEntity: [
+            TrainingTagData.fine
+        ])
+        
+        async let checkAddTag: () = confirmation { confirmation in
+            let result = await withCheckedContinuation { continuation in
+                mockRealm.expectedInsertResult = { actual in
+                    
+                    guard let target = try? #require(actual.first) else {
+                        
+                        continuation.resume(returning: false)
+                        return false
+                    }
+                    #expect(target.tagName == TrainingTagData.unfine.tagName)
+                    continuation.resume(returning: true)
+                    return true
+                }
+            }
+            
+            #expect(result)
+            confirmation()
+        }
+        
+        let testStore = TestStore(initialState: .init(
+            tagName: TrainingTagData.unfine.tagName,
+            isEnableSaveButton: true
+        ),
+                                  reducer: { AddTagFeature() }) {
+            
+            $0.trainingTagApi = TrainingTagClient.createCustomValue(mockRealm)
+            $0.dismiss = .init { dismissInvoke.setValue(true) }
+        }
+        
+        await testStore.send(.saveButtonTapped)
+        
+        await checkAddTag
+        #expect(dismissInvoke.value)
+    }
+    
+    @Test
+    func すでに存在するタグ名が入力されている状態でタグ保存ボタン押下すると保存に失敗する() async throws {
+        
+        let dismissInvoke = LockIsolated(false)
+        
+        let mockRealm = RealmAccessorMock(fetchEntity: [
+            TrainingTagData.fine
+        ]) { _ in
+            
+            Issue.record()
+            return false
+        }
+        let testStore = TestStore(initialState: .init(
+            tagName: TrainingTagData.fine.tagName,
+            isEnableSaveButton: true
+        ),
+                                  reducer: { AddTagFeature() }) {
+            
+            $0.trainingTagApi = TrainingTagClient.createCustomValue(mockRealm)
+            $0.dismiss = .init { dismissInvoke.setValue(true) }
+        }
+        
+        await testStore.send(.saveButtonTapped)
+        
+        #expect(dismissInvoke.value)
+    }
+}


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #79 

## 概要
タグの新規追加を行っても、DBに追加されず日記作成画面にも追加したタグが表示されない問題を修正

## 変更点

- タグ追加画面で同じタグ名を追加しようとしたときは失敗にするように修正
- タグ追加画面ですでに登録されていないタグ名は追加できるケースとすでに登録されているタグ名を追加しようとしたら失敗するケースをテストとして追加

## 影響範囲
タグ追加画面

## 動作確認

- シミュレーターで、新規タグが追加できることを確認
- UTが全て通ることを確認
