### PR TITLE
[AD1.0] 日記編集画面の実装_日記リストの配列処理をロジッククラスに移譲するリファクタ

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/DiaryListFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/DiaryListFeature.swift
@@ -30,7 +30,7 @@ struct DiaryListFeature: Sendable {
         /// フィルター反映後の日記リスト
         var filteredDiaries = IdentifiedArrayOf<DiaryListItemFeature.State>()
         /// 日記リストに表示する日記の項目の要素
-        @ObservationStateIgnored var diaries = IdentifiedArrayOf<DiaryListItemFeature.State>()
+        @ObservationStateIgnored var diaryList = DiaryList(elements: [])
         /// スクロール位置追跡リストのコンポーネントState
         @ObservationStateIgnored var trackableList = TrackableListFeature.State()
         
@@ -162,7 +162,7 @@ private extension DiaryListFeature {
                 
             case .alert(.presented(.confirmEditItem(targetId: let id))):
                 logger.info("tapped edit button(id=\(id)).")
-                guard let targetDiary = state.diaries.first(where: { $0.id == id }) else { return .none }
+                guard let targetDiary = state.diaryList.getTargetDiaryById(id) else { return .none }
                 state.path = .getToEditScreenPath(targetDiary.entity)
                 return .none
                 
@@ -210,7 +210,7 @@ private extension DiaryListFeature {
                 // ロード中にStateを更新する
                 state.viewState.isLoadingDiaries = true
                 // バウンスした際はデータをリロードする
-                return loadDiaryListItem(state.diaries.last?.date ?? date.now)
+                return loadDiaryListItem(state.diaryList.getLoadStartDate() ?? date.now)
                 
             case .trackableList:
                 return .none
@@ -229,18 +229,16 @@ private extension DiaryListFeature {
                 
             case .receiveLoadDiaryItems(let fetchedDiaries):
                 logger.info("receiveLoadDiaryItems(\(fetchedDiaries))")
-                let diaryList = DiaryList(adding: fetchedDiaries,
-                                          current: state.diaries.elements)
-                state = getUpdatedDiaryList(updatedList: diaryList, currentState: state)
+                state.diaryList.addLoadedDiaries(fetchedDiaries)
+                state = getUpdatedDiaryList(currentState: state)
                 // リロード中フラグを倒す
                 state.viewState.isLoadingDiaries = false
                 return .none
                 
             case .deletedDiaryItem(let id):
                 logger.info("deletedDiaryItem(id: \(id))")
-                let diaryList = DiaryList(removing: id, current: state.diaries.elements)
-                state = getUpdatedDiaryList(updatedList: diaryList, currentState: state)
-                
+                state.diaryList.deleteDiaryById(id)
+                state = getUpdatedDiaryList(currentState: state)
                 return .none
                 
             case .receiveLoadDiaryListFilter(let filters):
@@ -249,8 +247,7 @@ private extension DiaryListFeature {
                 // 現在のフィルターを更新
                 state.currentFilters = filters
                 // 日記リストのフィルター反映
-                let diaryList = DiaryList(elements: state.diaries.elements)
-                state = getUpdatedDiaryList(updatedList: diaryList, currentState: state)
+                state = getUpdatedDiaryList(currentState: state)
                 
                 return .none
             }
@@ -307,16 +304,14 @@ private extension DiaryListFeature {
         }
     }
     
-    func getUpdatedDiaryList(updatedList: DiaryList, currentState: State) -> State {
+    func getUpdatedDiaryList(currentState: State) -> State {
         
         var updatedState = currentState
-        updatedState.diaries = .init(uniqueElements: updatedList.elements)
+        let diaryList = updatedState.diaryList
+        let filteredDiaryList = diaryList.getFilteredList(filters: currentState.currentFilters)
         
-        let filteredDiaryList = updatedList.getFilteredList(filters: currentState.currentFilters)
-        updatedState.filteredDiaries = .init(
-            uniqueElements: filteredDiaryList.elements
-        )
-        updatedState.viewState.hasDiaryItems = filteredDiaryList.hasElements
+        updatedState.filteredDiaries = .init(uniqueElements: filteredDiaryList)
+        updatedState.viewState.hasDiaryItems = !filteredDiaryList.isEmpty
         return updatedState
     }
     
@@ -338,7 +333,7 @@ private extension DiaryListFeature {
         switch delegate {
             
         case .tappedDiaryItem:
-            if let diary = state.diaries.first(where: { $0.id == id }) {
+            if let diary = state.diaryList.getTargetDiaryById(id) {
                 
                 updateTargetState.path = .getToDetailScreenPath(diary.entity)
             }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/Entity/DiaryList.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryList/Entity/DiaryList.swift
@@ -11,16 +11,16 @@ import Foundation
 
 struct DiaryList: Equatable {
     
-    let elements: [DiaryListItemFeature.State]
+    var elements: [DiaryListItemFeature.State]
     var hasElements: Bool {
         
         return !elements.isEmpty
     }
     
-    func getFilteredList(filters: [DiaryListFilterItem]) -> Self {
-        
-        if filters.isEmpty { return self }
-        let filteredElements = elements.filter { item in
+    func getFilteredList(filters: [DiaryListFilterItem]) -> [DiaryListItemFeature.State] {
+
+        if filters.isEmpty { return elements }
+        return elements.filter { item in
             
             return filters.contains {
                 
@@ -29,17 +29,22 @@ struct DiaryList: Equatable {
                                         tagList: item.tagList)
             }
         }
-        
-        return .init(elements: filteredElements)
     }
-}
-
-extension DiaryList {
     
-    init(adding elements: [DiaryData], current: [DiaryListItemFeature.State]) {
+    func getTargetDiaryById(_ id: UUID) -> DiaryListItemFeature.State? {
         
-        let addingDiaryItemList = elements.map { DiaryListItemFeature.State($0) }
-        var sortElements = addingDiaryItemList.reduce(into: current) { current, new in
+        return elements.first { $0.id == id }
+    }
+    
+    func getLoadStartDate() -> Date? {
+        
+        return elements.last?.date
+    }
+    
+    mutating func addLoadedDiaries(_ diaries: [DiaryData]) {
+        
+        let addingDiaryItemList = diaries.map { DiaryListItemFeature.State($0) }
+        var sortElements = addingDiaryItemList.reduce(into: elements) { current, new in
             
             if let targetIndex = current.firstIndex(where: { $0.id == new.id }) {
                 
@@ -55,17 +60,14 @@ extension DiaryList {
         self.elements = sortElements
     }
     
-    init(removing id: UUID, current: [DiaryListItemFeature.State]) {
+    mutating func deleteDiaryById(_ id: UUID) {
         
-        var removedList = current
-        guard let targetIndex = removedList.firstIndex(where: { $0.id == id }) else {
+        guard let targetIndex = elements.firstIndex(where: { $0.id == id }) else {
             
             assertionFailure("Nothing remove target id.")
-            self.elements = current
             return
         }
         
-        removedList.remove(at: targetIndex)
-        self.elements = removedList
+        elements.remove(at: targetIndex)
     }
 }

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryList/DiaryListViewTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryList/DiaryListViewTest.swift
@@ -22,7 +22,7 @@ final class DiaryListViewTests: XCTestCase {
         
         let initialDiary = DiaryListItemFeature.State(.create(date: .distantFuture))
         let expectedAddedItem = DiaryListItemFeature.State(.create(date: .distantPast))
-        let expectedLoadedDiaries = IdentifiedArray(uniqueElements: [
+        let expectedLoadedDiaries = DiaryList(elements: [
             initialDiary,
             expectedAddedItem
         ])
@@ -36,7 +36,7 @@ final class DiaryListViewTests: XCTestCase {
         let viewState = DiaryListFeature.State.ViewState(hasDiaryItems: true)
         let store = TestStore(
             initialState: DiaryListFeature.State(
-                diaries: [initialDiary],
+                diaryList: .init(elements: [initialDiary]),
                 trackableList: trackableListState,
                 viewState: viewState
             ), reducer: { DiaryListFeature() }) {
@@ -55,8 +55,8 @@ final class DiaryListViewTests: XCTestCase {
         await store.receive(\.receiveLoadDiaryItems) {
             
             $0.viewState.isLoadingDiaries = false
-            $0.diaries = expectedLoadedDiaries
-            $0.filteredDiaries = expectedLoadedDiaries
+            $0.diaryList = expectedLoadedDiaries
+            $0.filteredDiaries = .init(uniqueElements: expectedLoadedDiaries.elements)
         }
     }
     
@@ -71,7 +71,7 @@ final class DiaryListViewTests: XCTestCase {
         
         let store = TestStore(
             initialState: DiaryListFeature.State(
-                diaries: [.init(.create())],
+                diaryList: .init(elements: [.init(.create())]),
                 trackableList: trackableListState,
                 viewState: viewState),
             reducer: { DiaryListFeature() })
@@ -113,7 +113,7 @@ final class DiaryListViewTests: XCTestCase {
         
         await store.receive(\.receiveLoadDiaryItems) {
             
-            $0.diaries = [expectedItem]
+            $0.diaryList = .init(elements: [expectedItem])
             $0.filteredDiaries = [expectedItem]
             $0.viewState.isLoadingDiaries = false
             $0.viewState.hasDiaryItems = true
@@ -132,7 +132,7 @@ final class DiaryListViewTests: XCTestCase {
         let store = TestStore(
             initialState: DiaryListFeature.State(
                 filteredDiaries: .init(uniqueElements: [initialFirstItem]),
-                diaries: .init(uniqueElements: [initialFirstItem]),
+                diaryList: .init(elements: [initialFirstItem]),
                 viewState: .init(hasDiaryItems: true)
             ),
             reducer: { DiaryListFeature() }
@@ -163,7 +163,7 @@ final class DiaryListViewTests: XCTestCase {
                 initialFirstItem,
                 fetchedNewItem
             ])
-            $0.diaries = expectedLoadedDiaries
+            $0.diaryList = .init(elements: expectedLoadedDiaries.elements)
             $0.filteredDiaries = expectedLoadedDiaries
             $0.viewState.isLoadingDiaries = false
             $0.viewState.hasDiaryItems = true
@@ -177,8 +177,10 @@ final class DiaryListViewTests: XCTestCase {
          ]
         
         let store = TestStore(
-            initialState: DiaryListFeature.State(filteredDiaries: diariesState,
-                                                 diaries: diariesState)) {
+            initialState: DiaryListFeature.State(
+                filteredDiaries: diariesState,
+                diaryList: .init(elements: diariesState.elements)
+            )) {
                 
             DiaryListFeature()
         }
@@ -200,9 +202,11 @@ final class DiaryListViewTests: XCTestCase {
         let viewState = DiaryListFeature.State.ViewState(hasDiaryItems: true)
         
         let store = TestStore(
-            initialState: DiaryListFeature.State(filteredDiaries: diariesState,
-                                                 diaries: diariesState,
-                                                 viewState: viewState)) {
+            initialState: DiaryListFeature.State(
+                filteredDiaries: diariesState,
+                diaryList: .init(elements: diariesState.elements),
+                viewState: viewState
+            )) {
                 
             DiaryListFeature()
         }
@@ -227,10 +231,12 @@ final class DiaryListViewTests: XCTestCase {
             firstButtonHandler: .confirmDeleteItem(deleteItemId: diariesState[0].id)
         )
         let store = TestStore(
-            initialState: DiaryListFeature.State(alert: deleteAlert,
-                                                 filteredDiaries: diariesState,
-                                                 diaries: diariesState,
-                                                 viewState: viewState)) {
+            initialState: DiaryListFeature.State(
+                alert: deleteAlert,
+                filteredDiaries: diariesState,
+                diaryList: .init(elements: diariesState.elements),
+                viewState: viewState
+            )) {
                 
             DiaryListFeature()
         }
@@ -245,7 +251,7 @@ final class DiaryListViewTests: XCTestCase {
         
         await store.receive(\.deletedDiaryItem) {
             
-            $0.diaries = .init(uniqueElements: [])
+            $0.diaryList = .init(elements: [])
             $0.filteredDiaries = .init(uniqueElements: [])
             $0.viewState.hasDiaryItems = false
         }
@@ -258,7 +264,10 @@ final class DiaryListViewTests: XCTestCase {
          ]
         
         let store = TestStore(
-            initialState: DiaryListFeature.State(filteredDiaries: diariesState, diaries: diariesState)) {
+            initialState: DiaryListFeature.State(
+                filteredDiaries: diariesState,
+                diaryList: .init(elements: diariesState.elements)
+            )) {
                 
             DiaryListFeature()
         }
@@ -281,9 +290,11 @@ final class DiaryListViewTests: XCTestCase {
             firstButtonHandler: .confirmEditItem(targetId: diariesState[0].id)
         )
         let store = TestStore(
-            initialState: DiaryListFeature.State(alert: alert,
-                                                 filteredDiaries: diariesState,
-                                                 diaries: diariesState)) {
+            initialState: DiaryListFeature.State(
+                alert: alert,
+                filteredDiaries: diariesState,
+                diaryList: .init(elements: diariesState.elements)
+            )) {
                 
             DiaryListFeature()
         }
@@ -349,7 +360,7 @@ final class DiaryListViewTests: XCTestCase {
         let testState = DiaryListFeature.State(
             destination: .init(childState: .init(viewState: .init(currentFilters: .init(uniqueElements: [])))),
             filteredDiaries: .init(),
-            diaries: .init(uniqueElements: [initialDiaryItem]),
+            diaryList: .init(elements: [initialDiaryItem]),
             viewState: .init(hasDiaryItems: false),
             currentFilters: initialFilters
         )

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryList/Entity/DiaryListTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryList/Entity/DiaryListTest.swift
@@ -175,6 +175,38 @@ struct DiaryListTest {
         
         #expect(sut.elements == [])
     }
+    
+    @Test
+    func IDで指定した日記を取得する() async throws {
+        
+        let inputDiaries: [DiaryData] = [
+            .create(id: Self.diaryIdList[0]),
+            .create(id: Self.diaryIdList[1], tag: [.fine]),
+            .create(id: Self.diaryIdList[2],
+                    isAchieved: true,
+                    type: [.benchPress],
+                    tag: [.unfine])
+        ]
+        var sut = DiaryList(elements: inputDiaries.map { .init($0) })
+        
+        let result = try #require(sut.getTargetDiaryById(Self.diaryIdList[0]))
+        
+        #expect(result == .init(inputDiaries[0]))
+    }
+    
+    @Test
+    func 次の日記を取得するための日記リストの一番古い日付を返す() async throws {
+        
+        let inputDiaries: [DiaryData] = [
+            .create(id: Self.diaryIdList[0], date: .create(year: 2025, month: 2, day: 2)),
+            .create(id: Self.diaryIdList[1], date: .create(year: 2024, month: 2, day: 2))
+        ]
+        var sut = DiaryList(elements: inputDiaries.map { .init($0) })
+        
+        let result = try #require(sut.getLoadStartDate())
+        
+        #expect(result == inputDiaries[1].date)
+    }
 }
 
 fileprivate extension DiaryData {

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryList/Entity/DiaryListTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryList/Entity/DiaryListTest.swift
@@ -111,31 +111,41 @@ struct DiaryListTest {
         
         let result = sut.getFilteredList(filters: inputFilter)
         
-        let expectedResult = DiaryList(elements: expected.map { .init($0) })
-        #expect(result == expectedResult)
-        #expect(result.hasElements == !expected.isEmpty)
+        #expect(result == expected.map { .init($0) })
     }
     
     @Test(
         arguments: [
             (
+                DiaryList(elements: []),
                 [
-                    DiaryData.create(id: diaryIdList[1], date: .create(year: 2025, month: 2, day: 2)),
-                    DiaryData.create(id: diaryIdList[2], date: .create(year: 2024, month: 2, day: 2))
+                    DiaryData.create(id: diaryIdList[2], date: .create(year: 2024, month: 2, day: 2)),
+                    .create(id: diaryIdList[1], date: .create(year: 2025, month: 2, day: 2))
                 ],
                 [
                     DiaryData.create(id: diaryIdList[1], date: .create(year: 2025, month: 2, day: 2)),
-                    DiaryData.create(id: diaryIdList[0], date: .create(year: 2025, month: 2, day: 1)),
-                    DiaryData.create(id: diaryIdList[2], date: .create(year: 2024, month: 2, day: 2))
+                    .create(id: diaryIdList[2], date: .create(year: 2024, month: 2, day: 2))
                 ]
             ),
             (
+                DiaryList(elements: []),
                 [DiaryData.create(id: diaryIdList[0], date: .create(year: 2025, month: 2, day: 1), tag: [.fine])],
-                [DiaryData.create(id: diaryIdList[0], date: .create(year: 2025, month: 2, day: 1), tag: [.fine])]
+                [.create(id: diaryIdList[0], date: .create(year: 2025, month: 2, day: 1), tag: [.fine])]
+            ),
+            (
+                DiaryList(elements: [
+                    .init(.create(id: diaryIdList[1], date: .create(year: 2025, month: 2, day: 10)))
+                ]),
+                [DiaryData.create(id: diaryIdList[0], date: .create(year: 2025, month: 2, day: 1))],
+                [
+                    .create(id: diaryIdList[1], date: .create(year: 2025, month: 2, day: 10)),
+                    .create(id: diaryIdList[0], date: .create(year: 2025, month: 2, day: 1))
+                ]
             )
         ]
     )
     func 追加の日記リストは既存の日記リストにマージし日記作成日の降順にする(
+        initialList: DiaryList,
         addingDiaries: [DiaryData],
         expected: [DiaryData]
     ) throws {
@@ -144,13 +154,12 @@ struct DiaryListTest {
             .create(id: Self.diaryIdList[0], date: .create(year: 2025, month: 2, day: 1)),
         ]
             .map { .init($0) }
-        let sut = DiaryList(adding: addingDiaries, current: currentDiaryItems)
         
-        let result = sut.elements
+        var sut = initialList
+        sut.addLoadedDiaries(addingDiaries)
         
-        let expectedResult: [DiaryListItem] = expected.map { .init($0) }
-        #expect(result == expectedResult)
-        #expect(sut.hasElements == !expected.isEmpty)
+        let expected = DiaryList(elements: expected.map { .init($0) })
+        #expect(sut == expected)
     }
     
     @Test
@@ -160,11 +169,11 @@ struct DiaryListTest {
             .create(id: Self.diaryIdList[0], date: .create(year: 2025, month: 2, day: 1)),
         ]
             .map { .init($0) }
-        let sut = DiaryList(removing: Self.diaryIdList[0], current: currentDiaryItems)
+        var sut = DiaryList(elements: currentDiaryItems)
         
-        let result = sut.elements
+        sut.deleteDiaryById(Self.diaryIdList[0])
         
-        #expect(result == [])
+        #expect(sut.elements == [])
     }
 }
 


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #72 

## 概要
前回PRで日記リスト画面の日記リストの配列操作のロジックが、Featureクラスにたくさんあることに気づいたので、ロジッククラスで行うように修正。

## 変更点

- 日記リストの配列操作のロジックを`DiaryList`クラスで行うように修正
- `DiaryList`のテストを追加
- 日記リスト画面のテストを修正

## 影響範囲
日記リスト画面

## 動作確認

- UTが全て通ること
- シミュレーターで日記リストを表示できること
- シミュレーターで日記リストを削除できること
- シミュレーターで日記を作成できること
- シミュレーターで日記編集画面へ遷移できること
