### PR TITLE
[AD1.0] 日記編集画面の実装_既存の日記を編集できるように修正

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -18,6 +18,8 @@ struct DiaryCreationFeature: Sendable {
     @ObservableState
     struct State: Equatable {
         
+        @ObservationStateIgnored var id: UUID?
+        var createdAt: Date?
         var titleText = ""
         var messageText = ""
         var tags: [Tag] = []
@@ -25,6 +27,7 @@ struct DiaryCreationFeature: Sendable {
         var isEnableStartButton = false
         var animationsRunning = false
         var textFieldFocusState: DiaryCreationTextFieldFocus?
+        var isEditMode = false
         
         @Presents var destination: Destination.State?
         @Presents var alert: AlertState<Action.Alert>?
@@ -40,6 +43,7 @@ struct DiaryCreationFeature: Sendable {
         case titleTextChange(String)
         case messageTextChange(String)
         case trainingStartButtonTapped
+        case trainingSaveButtonTapped
         case animateStartButton
         case destination(PresentationAction<Destination.Action>)
         case tappedAddingTagButton
@@ -105,6 +109,16 @@ struct DiaryCreationFeature: Sendable {
                     .run { [state] _ in
                         
                         await addDiary(state: state)
+                    },
+                    popToPrev()
+                )
+                
+            case .trainingSaveButtonTapped:
+                return .concatenate(
+                    .send(.animateStartButton),
+                    .run { [state] _ in
+                        
+                        await updateDiary(state: state)
                     },
                     popToPrev()
                 )
@@ -208,20 +222,30 @@ private extension DiaryCreationFeature {
         _ = await diaryListFetchApi.add(diary)
     }
     
+    func updateDiary(state: State) async {
+        
+        guard let id = state.id,
+              let createdAt = state.createdAt else {
+            
+            assertionFailure("Unexpected state.id is nil.")
+            return
+        }
+        let diary = DiaryData(id: id,
+                              date: createdAt,
+                              title: state.titleText,
+                              mainText: state.messageText,
+                              goals: state.goals.map(\.entity),
+                              tags: state.tags.map(\.entity),
+                              startTime: createdAt,
+                              endTime: nil)
+        _ = await diaryListFetchApi.add(diary)
+    }
+    
     func createDiary(state: State) -> DiaryData {
         
         let startDate = Date()
         
-        let goals = state.goals.map {
-            
-            TrainingContentData(id: $0.id,
-                                trainingType: $0.trainingType,
-                                goalNumberOfSets: $0.numberOfSets,
-                                goalSetCount: $0.setCount,
-                                actualNumberOfSets: nil,
-                                actualSetCount: nil)
-        }
-        
+        let goals = state.goals.map(\.entity)
         let tags = state.tags.map(\.entity)
         
         return DiaryData(id: UUID(),
@@ -304,6 +328,9 @@ extension DiaryCreationFeature.State {
     
     init(editTarget diary: DiaryData) {
         
+        isEditMode = true
+        id = diary.id
+        createdAt = diary.date
         titleText = diary.title
         messageText = diary.mainText
         tags = diary.tags.map { .init(entity: $0, isSelected: true) }
@@ -319,6 +346,5 @@ extension DiaryCreationFeature.State {
                          numberOfSets: $0.goalNumberOfSets,
                          setCount: $0.goalSetCount)
         }
-        
     }
 }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -101,6 +101,7 @@ struct DiaryCreationFeature: Sendable {
                 
             case .messageTextChange(let text):
                 state.messageText = text
+                state.isEnableStartButton = isEnableStartButton(state: state)
                 return .none
                 
             case .trainingStartButtonTapped:
@@ -271,7 +272,11 @@ private extension DiaryCreationFeature {
     
     func isEnableStartButton(state: State) -> Bool {
         
-        return !(state.titleText.isEmpty || state.goals.isEmpty)
+        let creatingDiary = CreatingDiary(title: state.titleText,
+                                          mainText: state.messageText,
+                                          goals: state.goals,
+                                          tags: state.tags)
+        return creatingDiary.canSave
     }
     
     func addObserveTagEntity() -> Effect<Self.Action> {

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -127,11 +127,23 @@ private extension DiaryCreationView {
             }
             .scrollIndicators(.hidden)
             
-            startButton(animationsRunning: store.animationsRunning, parentSize: parentSize) {
+            if store.isEditMode {
                 
-                store.send(.trainingStartButtonTapped)
+                editButton(animationsRunning: store.animationsRunning, parentSize: parentSize) {
+                    
+                    store.send(.trainingSaveButtonTapped)
+                }
             }
-            .padding(.bottom, startButtonBottomPadding)
+            else {
+                
+                startButton(animationsRunning: store.animationsRunning, parentSize: parentSize) {
+                    
+                    store.send(.trainingStartButtonTapped)
+                }
+            }
+            
+            Spacer()
+                .frame(maxHeight: startButtonBottomPadding)
         }
     }
     
@@ -295,6 +307,25 @@ private extension DiaryCreationView {
         }
         .frame(maxWidth: ViewUtil.calcWidth(size: parentSize, horizontalPadding: horizontalPadding),
                alignment: .leading)
+    }
+    
+    func editButton(animationsRunning: Bool,
+                    parentSize: CGSize,
+                    action: @escaping () -> Void) -> some View {
+        
+        Button(action: action, label: {
+            HStack {
+                Image(systemName: "figure.run.square.stack")
+                    .font(.system(size: 24))
+                    .symbolEffect(.bounce, value: animationsRunning)
+                Text("Save")
+                    .font(.system(size: textSize, weight: .bold))
+            }
+            .frame(maxWidth: ViewUtil.calcWidth(size: parentSize, horizontalPadding: horizontalPadding),
+                   minHeight: startButtonHeight)
+        })
+        .fillButtonStyle(backgroundColor: store.isEnableStartButton ? .orange : .gray)
+        .disabled(!store.isEnableStartButton)
     }
     
     func startButton(animationsRunning: Bool,

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
@@ -1,0 +1,25 @@
+//
+//  MachoFramework
+//
+//  CreatingDiary.swift
+//
+//  Created by stotic-dev on 2025/03/16
+//  Copyright © Macho All rights reserved.
+//
+
+struct CreatingDiary {
+    
+    let title: String?
+    let mainText: String?
+    let goals: [Goal]
+    let tags: [Tag]
+    
+    var canSave: Bool {
+        
+        if title?.isEmpty ?? true { return false }
+        if mainText?.isEmpty ?? true { return false }
+        if goals.isEmpty { return false }
+        
+        return true
+    }
+}

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Goal.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Goal.swift
@@ -15,4 +15,14 @@ struct Goal: Equatable, Identifiable {
     var trainingType: TrainingTypeData
     var numberOfSets: Int
     var setCount: Int
+    
+    var entity: TrainingContentData {
+        
+        return .init(id: id,
+                     trainingType: trainingType,
+                     goalNumberOfSets: numberOfSets,
+                     goalSetCount: setCount,
+                     actualNumberOfSets: nil,
+                     actualSetCount: nil)
+    }
 }


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #72 

## 概要
編集画面で日記の内容を修正して、保存ボタン押下すると修正した内容が保存されて、日記リストでも編集内容が反映されるように修正しました。

## 変更点

- 日記編集画面を開いたときは、保存ボタンを表示するようにする
- 既存の日記を編集画面で編集できるように修正

## 影響範囲
日記作成画面

## 動作確認

- シミュレーターで日記を編集できることを確認
- シミュレーターで新規の日記を作成できることを確認
- UTが全て通ることを確認