### PR TITLE
[AD1.0] 日記編集画面の実装_日記作成画面のロジックをドメインクラスに移譲するリファクタ

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/AddGoal/AddGoalFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/AddGoal/AddGoalFeature.swift
@@ -18,6 +18,7 @@ struct AddGoalFeature: Sendable {
     @ObservableState
     struct State: Equatable {
         
+        var id: UUID?
         var trainingTypes: [TrainingTypeData] = []
         var selectedTrainingType: TrainingTypeData?
         var typeNameBeingAdded: String?
@@ -55,6 +56,7 @@ struct AddGoalFeature: Sendable {
     
     @Dependency(\.trainingTypeApi) var trainingTypeApi
     @Dependency(\.dismiss) var dismiss
+    @Dependency(\.uuid) var uuid
     
     // MARK: - body
     
@@ -101,7 +103,7 @@ struct AddGoalFeature: Sendable {
                     
                     guard let goalType = state.selectedTrainingType else { return }
                     
-                    let goal = Goal(id: UUID(),
+                    let goal = Goal(id: state.id ?? uuid(),
                                     trainingType: goalType,
                                     numberOfSets: state.numberOfSets,
                                     setCount: state.setCount)

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Converter/TagConverter.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Converter/TagConverter.swift
@@ -1,0 +1,21 @@
+//
+//  MachoFramework
+//
+//  TagConverter.swift
+//
+//  Created by stotic-dev on 2025/03/16
+//  Copyright © Macho All rights reserved.
+//
+
+enum TagConverter {
+    
+    static func toTag(_ entity: TrainingTagData, isSelected: Bool = false) -> Tag {
+        
+        return .init(id: entity.id, tagName: entity.tagName, isSelected: isSelected)
+    }
+    
+    static func toEntity(_ tag: Tag) -> TrainingTagData {
+        
+        return .init(id: tag.id, tagName: tag.tagName)
+    }
+}

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -229,7 +229,7 @@ private extension DiaryCreationFeature {
                      title: title,
                      mainText: mainText,
                      goals: diary.goals.map(\.entity),
-                     tags: diary.tags.filter { $0.isSelected }.map { TagConverter.toEntity($0) },
+                     tags: diary.tags.filter(\.isSelected).map { TagConverter.toEntity($0) },
                      startTime: createdAt,
                      endTime: nil)
     }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -18,16 +18,15 @@ struct DiaryCreationFeature: Sendable {
     @ObservableState
     struct State: Equatable {
         
-        @ObservationStateIgnored var id: UUID?
-        var createdAt: Date?
+        @ObservationStateIgnored var useCase = CreatingDiaryUseCase(initial: .initial)
         var titleText = ""
         var messageText = ""
         var tags: [Tag] = []
         var goals: [Goal] = []
-        var isEnableStartButton = false
         var animationsRunning = false
         var textFieldFocusState: DiaryCreationTextFieldFocus?
-        var isEditMode = false
+        var isEnableStartButton: Bool { useCase.canSave }
+        var isEditMode: Bool { useCase.isEditMode }
         
         @Presents var destination: Destination.State?
         @Presents var alert: AlertState<Action.Alert>?
@@ -61,6 +60,8 @@ struct DiaryCreationFeature: Sendable {
     @Dependency(\.trainingTagApi) var trainingTagApi
     @Dependency(\.diaryListFetchApi) var diaryListFetchApi
     @Dependency(\.dismiss) var dismiss
+    @Dependency(\.uuid) var uuid
+    @Dependency(\.date) var date
     
     // MARK: - body
     
@@ -82,26 +83,18 @@ struct DiaryCreationFeature: Sendable {
                 return fetchTags()
                 
             case .fetchedTags(let tags):
-                state.tags = tags.map { entity in
-                    
-                    if let tag = state.tags.first(where: { $0.id == entity.id }) {
-                        
-                        return Tag(entity: entity, isSelected: tag.isSelected)
-                    }
-                    
-                    return Tag(entity: entity)
-                }
+                let tags = tags.map { TagConverter.toTag($0) }
+                state = updateCreatingDiaryState(state.useCase.updateTags(tags),
+                                                 state: state)
                 return .none
                 
             case .titleTextChange(let text):
                 if state.titleText.isEmpty, text.isEmpty { return .none }
-                state.titleText = text
-                state.isEnableStartButton = isEnableStartButton(state: state)
+                state = updateCreatingDiaryState(state.useCase.editTitle(title: text), state: state)
                 return .none
                 
             case .messageTextChange(let text):
-                state.messageText = text
-                state.isEnableStartButton = isEnableStartButton(state: state)
+                state = updateCreatingDiaryState(state.useCase.editMainText(mainText: text), state: state)
                 return .none
                 
             case .trainingStartButtonTapped:
@@ -109,7 +102,7 @@ struct DiaryCreationFeature: Sendable {
                     .send(.animateStartButton),
                     .run { [state] _ in
                         
-                        await addDiary(state: state)
+                        await saveDiary(diary: state.useCase.edited)
                     },
                     popToPrev()
                 )
@@ -119,7 +112,7 @@ struct DiaryCreationFeature: Sendable {
                     .send(.animateStartButton),
                     .run { [state] _ in
                         
-                        await updateDiary(state: state)
+                        await saveDiary(diary: state.useCase.edited)
                     },
                     popToPrev()
                 )
@@ -138,13 +131,13 @@ struct DiaryCreationFeature: Sendable {
             case .tappedTag(let tag):
                 withAnimation(.easeIn(duration: 0.15)) {
                     
-                    state.tags = updateTagSelectedState(target: tag, currentList: state.tags)
+                    state = updateCreatingDiaryState(state.useCase.selectTag(tag), state: state)
                 }
                 return .none
                 
             case .longTappedTag(let tag):
                 state.destination = .addTag(AddTagFeature.State(id: tag.id,
-                                                                tagName: tag.entity.tagName,
+                                                                tagName: tag.tagName,
                                                                 isEnableSaveButton: true))
                 return .none
                 
@@ -155,8 +148,7 @@ struct DiaryCreationFeature: Sendable {
             case .deletedGoal(let goal):
                 withAnimation(.easeIn(duration: 0.5)) {
                     
-                    state.goals.removeAll(where: { $0.id == goal.id })
-                    state.isEnableStartButton = isEnableStartButton(state: state)
+                    state = updateCreatingDiaryState(state.useCase.removeGoal(goal), state: state)
                 }
                 return .none
                 
@@ -181,14 +173,7 @@ struct DiaryCreationFeature: Sendable {
                 return .none
                 
             case .destination(.presented(.addGoal(.delegate(.saveGoal(let goal))))):
-                guard let index = state.goals.firstIndex(where: { $0.trainingType == goal.trainingType }) else {
-                    
-                    state.goals.append(goal)
-                    state.isEnableStartButton = isEnableStartButton(state: state)
-                    return .none
-                }
-                state.goals[index] = goal
-                state.isEnableStartButton = isEnableStartButton(state: state)
+                state = updateCreatingDiaryState(state.useCase.addGoal(goal), state: state)
                 return .none
                 
             case .alert(.presented(.tappedDismissAcceptButton)):
@@ -217,46 +202,33 @@ private extension DiaryCreationFeature {
         }
     }
     
-    func addDiary(state: State) async {
+    func saveDiary(diary: CreatingDiary?) async {
         
-        let diary = createDiary(state: state)
-        _ = await diaryListFetchApi.add(diary)
+        guard let diary,
+              let entity = convertToDbEntity(diary: diary) else { return }
+        _ = await diaryListFetchApi.add(entity)
     }
     
-    func updateDiary(state: State) async {
+    func convertToDbEntity(diary: CreatingDiary) -> DiaryData? {
         
-        guard let id = state.id,
-              let createdAt = state.createdAt else {
+        guard let title = diary.title,
+              let mainText = diary.mainText else {
             
-            assertionFailure("Unexpected state.id is nil.")
-            return
+            assertionFailure("Unexpected empty diary data.")
+            return nil
         }
-        let diary = DiaryData(id: id,
-                              date: createdAt,
-                              title: state.titleText,
-                              mainText: state.messageText,
-                              goals: state.goals.map(\.entity),
-                              tags: state.tags.map(\.entity),
-                              startTime: createdAt,
-                              endTime: nil)
-        _ = await diaryListFetchApi.add(diary)
-    }
-    
-    func createDiary(state: State) -> DiaryData {
         
-        let startDate = Date()
+        let id = diary.id ?? uuid()
+        let createdAt = diary.createdAt ?? date()
         
-        let goals = state.goals.map(\.entity)
-        let tags = state.tags.map(\.entity)
-        
-        return DiaryData(id: UUID(),
-                         date: startDate,
-                         title: state.titleText,
-                         mainText: state.messageText,
-                         goals: goals,
-                         tags: tags,
-                         startTime: startDate,
-                         endTime: nil)
+        return .init(id: id,
+                     date: createdAt,
+                     title: title,
+                     mainText: mainText,
+                     goals: diary.goals.map(\.entity),
+                     tags: diary.tags.filter { $0.isSelected }.map { TagConverter.toEntity($0) },
+                     startTime: createdAt,
+                     endTime: nil)
     }
     
     func popToPrev() -> Effect<Self.Action> {
@@ -270,15 +242,6 @@ private extension DiaryCreationFeature {
         )
     }
     
-    func isEnableStartButton(state: State) -> Bool {
-        
-        let creatingDiary = CreatingDiary(title: state.titleText,
-                                          mainText: state.messageText,
-                                          goals: state.goals,
-                                          tags: state.tags)
-        return creatingDiary.canSave
-    }
-    
     func addObserveTagEntity() -> Effect<Self.Action> {
         
         return .publisher {
@@ -289,18 +252,29 @@ private extension DiaryCreationFeature {
         }.cancellable(id: TrainingTagsSubscriber())
     }
     
-    func updateTagSelectedState(target: Tag, currentList: [Tag]) -> [Tag] {
+    func updateCreatingDiaryState(_ editEvent: CreatingDiaryUseCase.EditEvent, state: State) -> State {
         
-        guard let targetIndex = currentList.firstIndex(where: { $0 == target }) else {
+        var updateState = state
+        switch editEvent {
             
-            return currentList
+        case .title(let useCase):
+            updateState.titleText = editEvent.currentDiary.title ?? ""
+            updateState.useCase = useCase
+            
+        case .mainText(let useCase):
+            updateState.messageText = editEvent.currentDiary.mainText ?? ""
+            updateState.useCase = useCase
+            
+        case .tags(let useCase):
+            updateState.tags = editEvent.currentDiary.tags
+            updateState.useCase = useCase
+            
+        case .goals(let useCase):
+            updateState.goals = editEvent.currentDiary.goals
+            updateState.useCase = useCase
         }
         
-        var result = currentList
-        let currentTag = result[targetIndex]
-        result[targetIndex] = .init(entity: target.entity,
-                                    isSelected: !currentTag.isSelected)
-        return result
+        return updateState
     }
 }
 
@@ -333,13 +307,7 @@ extension DiaryCreationFeature.State {
     
     init(editTarget diary: DiaryData) {
         
-        isEditMode = true
-        id = diary.id
-        createdAt = diary.date
-        titleText = diary.title
-        messageText = diary.mainText
-        tags = diary.tags.map { .init(entity: $0, isSelected: true) }
-        goals = diary.goals.compactMap {
+        let goals: [Goal] = diary.goals.compactMap {
             
             guard let trainingType = $0.trainingType else {
                 
@@ -351,5 +319,18 @@ extension DiaryCreationFeature.State {
                          numberOfSets: $0.goalNumberOfSets,
                          setCount: $0.goalSetCount)
         }
+        let tags: [Tag] = diary.tags.map { TagConverter.toTag($0, isSelected: true) }
+        let creatingDiary = CreatingDiary(id: diary.id,
+                                          createdAt: diary.date,
+                                          title: diary.title,
+                                          mainText: diary.mainText,
+                                          goals: goals,
+                                          tags: tags)
+        
+        useCase = .init(initial: creatingDiary)
+        titleText = diary.title
+        messageText = diary.mainText
+        self.tags = tags
+        self.goals = goals
     }
 }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -153,10 +153,13 @@ struct DiaryCreationFeature: Sendable {
                 return .none
                 
             case .editingGoal(let goal):
-                state.destination = .addGoal(AddGoalFeature.State(selectedTrainingType: goal.trainingType,
-                                                                  numberOfSets: goal.numberOfSets,
-                                                                  setCount: goal.setCount,
-                                                                  isEnableSaveButton: true))
+                state.destination = .addGoal(AddGoalFeature.State(
+                    id: goal.id,
+                    selectedTrainingType: goal.trainingType,
+                    numberOfSets: goal.numberOfSets,
+                    setCount: goal.setCount,
+                    isEnableSaveButton: true
+                ))
                 return .none
                 
             case .didChangeFocusState(let newState):

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -233,7 +233,7 @@ private extension DiaryCreationView {
                 // tapとlongPressのイベントをハンドルするため、actionでは何もしない
                 Button(action: {}, label: {
                     HStack(spacing: 4) {
-                        Text(tag.entity.tagName)
+                        Text(tag.tagName)
                             .font(.system(size: textSize, weight: tag.isSelected ? .semibold : .regular))
                         
                         Image(systemName: tag.isSelected ? "checkmark.circle.fill" : "circle.dashed")
@@ -360,7 +360,7 @@ private extension DiaryCreationView {
 
 #Preview("タグあり(ひとつだけ)") {
     DiaryCreationView(store: Store(initialState: DiaryCreationFeature.State(
-        tags: [.init(entity: .init(id: UUID(), tagName: "test"))]
+        tags: [.init(id: UUID(), tagName: "test", isSelected: false)]
     )) {
         
         DiaryCreationFeature()
@@ -370,13 +370,13 @@ private extension DiaryCreationView {
 #Preview("タグあり(複数)") {
     DiaryCreationView(store: Store(initialState: DiaryCreationFeature.State(
         tags: [
-            .init(entity: .init(id: UUID(), tagName: "test1")),
-            .init(entity: .init(id: UUID(), tagName: "test2")),
-            .init(entity: .init(id: UUID(), tagName: "test3")),
-            .init(entity: .init(id: UUID(), tagName: "test4")),
-            .init(entity: .init(id: UUID(), tagName: "test5")),
-            .init(entity: .init(id: UUID(), tagName: "test6")),
-            .init(entity: .init(id: UUID(), tagName: "test7"))
+            .init(id: UUID(), tagName: "test1", isSelected: true),
+            .init(id: UUID(), tagName: "test2", isSelected: true),
+            .init(id: UUID(), tagName: "test3", isSelected: false),
+            .init(id: UUID(), tagName: "test4", isSelected: false),
+            .init(id: UUID(), tagName: "test5", isSelected: false),
+            .init(id: UUID(), tagName: "test6", isSelected: false),
+            .init(id: UUID(), tagName: "test7", isSelected: false)
         ]
     )) {
         

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
@@ -9,175 +9,6 @@
 
 import Foundation
 
-struct CreatingDiaryUseCase: Equatable {
-    
-    private let initial: CreatingDiary
-    let edited: CreatingDiary?
-    
-    init(initial: CreatingDiary) {
-        
-        self.initial = initial
-        edited = nil
-    }
-    
-    var isEditMode: Bool {
-        
-        return initial.isEditMode
-    }
-    
-    var canSave: Bool {
-        
-        return edited?.canSave ?? false
-    }
-    
-    func editTitle(title: String) -> EditEvent {
-        
-        return .title(edit(title: title))
-    }
-    
-    func editMainText(mainText: String) -> EditEvent {
-        
-        return .mainText(edit(mainText: mainText))
-    }
-    
-    func addGoal(_ goal: Goal) -> EditEvent {
-        
-        var updateGoals = edited?.goals ?? initial.goals
-        guard let targetIndex = updateGoals.firstIndex(where: { $0.id == goal.id }) else {
-            
-            return .goals(edit(goals: updateGoals + [goal]))
-        }
-                
-        updateGoals[targetIndex] = goal
-        return .goals(edit(goals: updateGoals))
-    }
-    
-    func removeGoal(_ goal: Goal) -> EditEvent {
-        
-        let targetGoals = edited?.goals ?? initial.goals
-        guard let targetIndex = targetGoals.firstIndex(of: goal) else {
-            
-            return .goals(edit())
-        }
-        
-        return .goals(edit(goals: targetGoals.dropFirst(targetIndex).map(\.self)))
-    }
-    
-    func selectTag(_ tag: Tag) -> EditEvent {
-        
-        let updateTags = edited?.tags ?? initial.tags
-        return .tags(edit(tags: updateTags.map {
-            
-            $0 == tag ? .init(id: $0.id, tagName: $0.tagName, isSelected: !$0.isSelected) : $0
-        }))
-    }
-    
-    func updateTags(_ tags: [Tag]) -> EditEvent {
-        
-        let newInitial = CreatingDiary(
-            id: initial.id,
-            createdAt: initial.createdAt,
-            title: initial.title,
-            mainText: initial.mainText,
-            goals: initial.goals,
-            tags: tags.map { tag in
-                
-                guard let actualTag = initial.tags.first(where: { $0.id == tag.id }) else {
-                    
-                    return tag
-                }
-                
-                return actualTag
-            }
-        )
-        
-        guard let edited else { return .tags(.init(initial: newInitial)) }
-        
-        let newEdited = CreatingDiary(
-            id: edited.id,
-            createdAt: edited.createdAt,
-            title: edited.title,
-            mainText: edited.mainText,
-            goals: edited.goals,
-            tags: tags.map { tag in
-                
-                guard let actualTag = edited.tags.first(where: { $0.id == tag.id }) else {
-                    
-                    return tag
-                }
-                
-                return actualTag
-            }
-        )
-        
-        return .tags(.init(initial: newInitial, edited: newEdited))
-    }
-}
-
-extension CreatingDiaryUseCase {
-    
-    enum EditEvent {
-        
-        case title(CreatingDiaryUseCase)
-        case mainText(CreatingDiaryUseCase)
-        case tags(CreatingDiaryUseCase)
-        case goals(CreatingDiaryUseCase)
-        
-        var currentDiary: CreatingDiary {
-            
-            let useCase = switch self {
-            case .title(let creatingDiaryUseCase):
-                creatingDiaryUseCase
-                
-            case .mainText(let creatingDiaryUseCase):
-                creatingDiaryUseCase
-                
-            case .tags(let creatingDiaryUseCase):
-                creatingDiaryUseCase
-                
-            case .goals(let creatingDiaryUseCase):
-                creatingDiaryUseCase
-            }
-            
-            guard let edited = useCase.edited else {
-                
-                return useCase.initial
-            }
-            return edited
-        }
-    }
-}
-
-private extension CreatingDiaryUseCase {
-    
-    init(initial: CreatingDiary, edited: CreatingDiary?) {
-        
-        self.initial = initial
-        self.edited = edited
-    }
-    
-    private func edit(title: String? = nil,
-                      mainText: String? = nil,
-                      goals: [Goal]? = nil,
-                      tags: [Tag]? = nil) -> Self {
-        
-        let edited = CreatingDiary(id: initial.id,
-                                   createdAt: initial.createdAt,
-                                   title: title ?? initial.title,
-                                   mainText: mainText ?? initial.mainText,
-                                   goals: goals ?? initial.goals,
-                                   tags: tags ?? initial.tags)
-        if initial != edited {
-            
-            return .init(initial: initial, edited: edited)
-        }
-        else {
-            
-            return .init(initial: initial, edited: nil)
-        }
-    }
-}
-
 struct CreatingDiary: Equatable {
     
     let id: UUID?
@@ -186,7 +17,7 @@ struct CreatingDiary: Equatable {
     let mainText: String?
     let goals: [Goal]
     let tags: [Tag]
-            
+    
     var canSave: Bool {
         
         if title?.isEmpty ?? true { return false }
@@ -199,6 +30,19 @@ struct CreatingDiary: Equatable {
     var isEditMode: Bool {
         
         return id != nil && createdAt != nil && canSave
+    }
+    
+    func edit(title: String? = nil,
+              mainText: String? = nil,
+              goals: [Goal]? = nil,
+              tags: [Tag]? = nil) -> Self {
+        
+        return .init(id: self.id,
+                     createdAt: self.createdAt,
+                     title: title ?? self.title,
+                     mainText: mainText ?? self.mainText,
+                     goals: goals ?? self.goals,
+                     tags: tags ?? self.tags)
     }
 }
 

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
@@ -7,13 +7,182 @@
 //  Copyright © Macho All rights reserved.
 //
 
-struct CreatingDiary {
+import Foundation
+
+struct CreatingDiaryUseCase: Equatable {
     
+    private let initial: CreatingDiary
+    let edited: CreatingDiary?
+    
+    init(initial: CreatingDiary) {
+        
+        self.initial = initial
+        edited = nil
+    }
+    
+    var isEditMode: Bool {
+        
+        return initial.isEditMode
+    }
+    
+    var canSave: Bool {
+        
+        return edited?.canSave ?? false
+    }
+    
+    func editTitle(title: String) -> EditEvent {
+        
+        return .title(edit(title: title))
+    }
+    
+    func editMainText(mainText: String) -> EditEvent {
+        
+        return .mainText(edit(mainText: mainText))
+    }
+    
+    func addGoal(_ goal: Goal) -> EditEvent {
+        
+        var updateGoals = edited?.goals ?? initial.goals
+        guard let targetIndex = updateGoals.firstIndex(of: goal) else {
+            
+            return .goals(edit(goals: updateGoals + [goal]))
+        }
+                
+        updateGoals[targetIndex] = goal
+        return .goals(edit(goals: updateGoals))
+    }
+    
+    func removeGoal(_ goal: Goal) -> EditEvent {
+        
+        let targetGoals = edited?.goals ?? initial.goals
+        guard let targetIndex = targetGoals.firstIndex(of: goal) else {
+            
+            return .goals(edit())
+        }
+        
+        return .goals(edit(goals: targetGoals.dropFirst(targetIndex).map(\.self)))
+    }
+    
+    func selectTag(_ tag: Tag) -> EditEvent {
+        
+        let updateTags = edited?.tags ?? initial.tags
+        return .tags(edit(tags: updateTags.map {
+            
+            $0 == tag ? .init(id: $0.id, tagName: $0.tagName, isSelected: !$0.isSelected) : $0
+        }))
+    }
+    
+    func updateTags(_ tags: [Tag]) -> EditEvent {
+        
+        let newInitial = CreatingDiary(id: initial.id,
+                                       createdAt: initial.createdAt,
+                                       title: initial.title,
+                                       mainText: initial.mainText,
+                                       goals: initial.goals,
+                                       tags: tags.map { tag in
+            
+            guard let actualTag = initial.tags.first(where: { $0.id == tag.id }) else {
+                
+                return tag
+            }
+            
+            return actualTag
+        })
+        
+        guard let edited else { return .tags(.init(initial: newInitial)) }
+        
+        let newEdited = CreatingDiary(id: edited.id,
+                                      createdAt: edited.createdAt,
+                                      title: edited.title,
+                                      mainText: edited.mainText,
+                                      goals: edited.goals,
+                                      tags: tags.map { tag in
+            
+            guard let actualTag = edited.tags.first(where: { $0.id == tag.id }) else {
+                
+                return tag
+            }
+            
+            return actualTag
+        })
+        
+        return .tags(.init(initial: newInitial, edited: newEdited))
+    }
+}
+
+extension CreatingDiaryUseCase {
+    
+    enum EditEvent {
+        
+        case title(CreatingDiaryUseCase)
+        case mainText(CreatingDiaryUseCase)
+        case tags(CreatingDiaryUseCase)
+        case goals(CreatingDiaryUseCase)
+        
+        var currentDiary: CreatingDiary {
+            
+            let useCase = switch self {
+            case .title(let creatingDiaryUseCase):
+                creatingDiaryUseCase
+                
+            case .mainText(let creatingDiaryUseCase):
+                creatingDiaryUseCase
+                
+            case .tags(let creatingDiaryUseCase):
+                creatingDiaryUseCase
+                
+            case .goals(let creatingDiaryUseCase):
+                creatingDiaryUseCase
+            }
+            
+            guard let edited = useCase.edited else {
+                
+                return useCase.initial
+            }
+            return edited
+        }
+    }
+}
+
+private extension CreatingDiaryUseCase {
+    
+    init(initial: CreatingDiary, edited: CreatingDiary?) {
+        
+        self.initial = initial
+        self.edited = edited
+    }
+    
+    private func edit(title: String? = nil,
+                      mainText: String? = nil,
+                      goals: [Goal]? = nil,
+                      tags: [Tag]? = nil) -> Self {
+        
+        let edited = CreatingDiary(id: initial.id,
+                                   createdAt: initial.createdAt,
+                                   title: title ?? initial.title,
+                                   mainText: mainText ?? initial.mainText,
+                                   goals: goals ?? initial.goals,
+                                   tags: tags ?? initial.tags)
+        if initial != edited {
+            
+            return .init(initial: initial, edited: edited)
+        }
+        else {
+            
+            return .init(initial: initial, edited: nil)
+        }
+    }
+}
+
+struct CreatingDiary: Equatable {
+    
+    let id: UUID?
+    let createdAt: Date?
     let title: String?
     let mainText: String?
     let goals: [Goal]
     let tags: [Tag]
-    
+            
     var canSave: Bool {
         
         if title?.isEmpty ?? true { return false }
@@ -22,4 +191,19 @@ struct CreatingDiary {
         
         return true
     }
+    
+    var isEditMode: Bool {
+        
+        return id != nil && createdAt != nil && canSave
+    }
+}
+
+extension CreatingDiary {
+    
+    static let initial: Self = .init(id: nil,
+                                     createdAt: nil,
+                                     title: nil,
+                                     mainText: nil,
+                                     goals: [],
+                                     tags: [])
 }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
@@ -43,7 +43,7 @@ struct CreatingDiaryUseCase: Equatable {
     func addGoal(_ goal: Goal) -> EditEvent {
         
         var updateGoals = edited?.goals ?? initial.goals
-        guard let targetIndex = updateGoals.firstIndex(of: goal) else {
+        guard let targetIndex = updateGoals.firstIndex(where: { $0.id == goal.id }) else {
             
             return .goals(edit(goals: updateGoals + [goal]))
         }
@@ -74,37 +74,41 @@ struct CreatingDiaryUseCase: Equatable {
     
     func updateTags(_ tags: [Tag]) -> EditEvent {
         
-        let newInitial = CreatingDiary(id: initial.id,
-                                       createdAt: initial.createdAt,
-                                       title: initial.title,
-                                       mainText: initial.mainText,
-                                       goals: initial.goals,
-                                       tags: tags.map { tag in
-            
-            guard let actualTag = initial.tags.first(where: { $0.id == tag.id }) else {
+        let newInitial = CreatingDiary(
+            id: initial.id,
+            createdAt: initial.createdAt,
+            title: initial.title,
+            mainText: initial.mainText,
+            goals: initial.goals,
+            tags: tags.map { tag in
                 
-                return tag
+                guard let actualTag = initial.tags.first(where: { $0.id == tag.id }) else {
+                    
+                    return tag
+                }
+                
+                return actualTag
             }
-            
-            return actualTag
-        })
+        )
         
         guard let edited else { return .tags(.init(initial: newInitial)) }
         
-        let newEdited = CreatingDiary(id: edited.id,
-                                      createdAt: edited.createdAt,
-                                      title: edited.title,
-                                      mainText: edited.mainText,
-                                      goals: edited.goals,
-                                      tags: tags.map { tag in
-            
-            guard let actualTag = edited.tags.first(where: { $0.id == tag.id }) else {
+        let newEdited = CreatingDiary(
+            id: edited.id,
+            createdAt: edited.createdAt,
+            title: edited.title,
+            mainText: edited.mainText,
+            goals: edited.goals,
+            tags: tags.map { tag in
                 
-                return tag
+                guard let actualTag = edited.tags.first(where: { $0.id == tag.id }) else {
+                    
+                    return tag
+                }
+                
+                return actualTag
             }
-            
-            return actualTag
-        })
+        )
         
         return .tags(.init(initial: newInitial, edited: newEdited))
     }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
@@ -12,10 +12,10 @@ struct CreatingDiaryUseCase: Equatable {
     private let initial: CreatingDiary
     let edited: CreatingDiary?
     
-    init(initial: CreatingDiary) {
+    init(initial: CreatingDiary, edited: CreatingDiary? = nil) {
         
         self.initial = initial
-        edited = nil
+        self.edited = edited
     }
     
     var isEditMode: Bool {
@@ -101,7 +101,7 @@ struct CreatingDiaryUseCase: Equatable {
 
 extension CreatingDiaryUseCase {
     
-    enum EditEvent {
+    enum EditEvent: Equatable {
         
         case title(CreatingDiaryUseCase)
         case mainText(CreatingDiaryUseCase)
@@ -134,12 +134,6 @@ extension CreatingDiaryUseCase {
 }
 
 private extension CreatingDiaryUseCase {
-    
-    init(initial: CreatingDiary, edited: CreatingDiary?) {
-        
-        self.initial = initial
-        self.edited = edited
-    }
     
     func edit(title: String? = nil,
               mainText: String? = nil,

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
@@ -1,0 +1,162 @@
+//
+//  MachoFramework
+//
+//  CreatingDiaryUseCase.swift
+//
+//  Created by stotic-dev on 2025/03/16
+//  Copyright © Macho All rights reserved.
+//
+
+struct CreatingDiaryUseCase: Equatable {
+    
+    private let initial: CreatingDiary
+    let edited: CreatingDiary?
+    
+    init(initial: CreatingDiary) {
+        
+        self.initial = initial
+        edited = nil
+    }
+    
+    var isEditMode: Bool {
+        
+        return initial.isEditMode
+    }
+    
+    var canSave: Bool {
+        
+        return edited?.canSave ?? false
+    }
+    
+    func editTitle(title: String) -> EditEvent {
+        
+        return .title(edit(title: title))
+    }
+    
+    func editMainText(mainText: String) -> EditEvent {
+        
+        return .mainText(edit(mainText: mainText))
+    }
+    
+    func addGoal(_ goal: Goal) -> EditEvent {
+        
+        var updateGoals = edited?.goals ?? initial.goals
+        guard let targetIndex = updateGoals.firstIndex(where: { $0.id == goal.id }) else {
+            
+            return .goals(edit(goals: updateGoals + [goal]))
+        }
+        
+        updateGoals[targetIndex] = goal
+        return .goals(edit(goals: updateGoals))
+    }
+    
+    func removeGoal(_ goal: Goal) -> EditEvent {
+        
+        let targetGoals = edited?.goals ?? initial.goals
+        guard let targetIndex = targetGoals.firstIndex(of: goal) else {
+            
+            return .goals(edit())
+        }
+        
+        return .goals(edit(goals: targetGoals.dropFirst(targetIndex).map(\.self)))
+    }
+    
+    func selectTag(_ tag: Tag) -> EditEvent {
+        
+        let updateTags = edited?.tags ?? initial.tags
+        return .tags(edit(tags: updateTags.map {
+            
+            $0 == tag ? .init(id: $0.id, tagName: $0.tagName, isSelected: !$0.isSelected) : $0
+        }))
+    }
+    
+    func updateTags(_ tags: [Tag]) -> EditEvent {
+        
+        let initialUpdatedTags = tags.map { tag in
+            
+            guard let actualTag = initial.tags.first(where: { $0.id == tag.id }) else {
+                
+                return tag
+            }
+            
+            return actualTag
+        }
+        let newInitial = initial.edit(tags: initialUpdatedTags)
+        
+        guard let edited else { return .tags(.init(initial: newInitial)) }
+        
+        let editedUpdatedTags = tags.map { tag in
+            
+            guard let actualTag = edited.tags.first(where: { $0.id == tag.id }) else {
+                
+                return tag
+            }
+            
+            return actualTag
+        }
+        let newEdited = edited.edit(tags: editedUpdatedTags)
+        return .tags(.init(initial: newInitial, edited: newEdited))
+    }
+}
+
+extension CreatingDiaryUseCase {
+    
+    enum EditEvent {
+        
+        case title(CreatingDiaryUseCase)
+        case mainText(CreatingDiaryUseCase)
+        case tags(CreatingDiaryUseCase)
+        case goals(CreatingDiaryUseCase)
+        
+        var currentDiary: CreatingDiary {
+            
+            let useCase = switch self {
+            case .title(let creatingDiaryUseCase):
+                creatingDiaryUseCase
+                
+            case .mainText(let creatingDiaryUseCase):
+                creatingDiaryUseCase
+                
+            case .tags(let creatingDiaryUseCase):
+                creatingDiaryUseCase
+                
+            case .goals(let creatingDiaryUseCase):
+                creatingDiaryUseCase
+            }
+            
+            guard let edited = useCase.edited else {
+                
+                return useCase.initial
+            }
+            return edited
+        }
+    }
+}
+
+private extension CreatingDiaryUseCase {
+    
+    init(initial: CreatingDiary, edited: CreatingDiary?) {
+        
+        self.initial = initial
+        self.edited = edited
+    }
+    
+    func edit(title: String? = nil,
+              mainText: String? = nil,
+              goals: [Goal]? = nil,
+              tags: [Tag]? = nil) -> Self {
+        
+        let edited = (edited ?? initial).edit(title: title,
+                                              mainText: mainText,
+                                              goals: goals,
+                                              tags: tags)
+        if initial != edited {
+            
+            return .init(initial: initial, edited: edited)
+        }
+        else {
+            
+            return .init(initial: initial, edited: nil)
+        }
+    }
+}

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Tag.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Tag.swift
@@ -11,7 +11,7 @@ import Foundation
 
 struct Tag: Equatable, Identifiable {
     
-    var id: UUID { entity.id }
-    let entity: TrainingTagData
-    var isSelected = false
+    let id: UUID
+    let tagName: String
+    let isSelected: Bool
 }

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/Entity/CreatingDiaryUseCaseTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/Entity/CreatingDiaryUseCaseTest.swift
@@ -1,0 +1,273 @@
+//
+//  MachoFramework
+//
+//  CreatingDiaryUseCaseTest.swift
+//
+//  Created by stotic-dev on 2025/03/16
+//  Copyright © Macho All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import MachoView
+
+struct CreatingDiaryUseCaseTest {
+    
+    @Suite("保存可能判定処理のケース")
+    struct CanSaveCase {}
+    
+    @Suite("日記内容入力処理のケース")
+    struct EditCase {}
+}
+
+extension CreatingDiaryUseCaseTest.CanSaveCase {
+    
+    @Test(arguments: [
+        (CreatingDiary.make(id: nil, createdAt: nil), true),
+        (CreatingDiary.make(id: nil, createdAt: nil, tags: []), true),
+        (.make(id: nil, createdAt: nil, title: ""), false),
+        (.make(id: nil, createdAt: nil, mainText: ""), false),
+        (.make(id: nil, createdAt: nil, goals: []), false),
+        (Optional(nilLiteral: ()), false),
+    ])
+    func タイトルと本文と目標が設定されており編集前と異なる内容の場合は保存可能となる(
+        inputEditedDiary: CreatingDiary?,
+        expected: Bool
+    ) throws {
+        
+        let sut = CreatingDiaryUseCase(
+            initial: CreatingDiary.make(),
+            edited: inputEditedDiary
+        )
+        
+        let result = sut.canSave
+        
+        #expect(result == expected)
+    }
+    
+    @Test(arguments: [
+        (CreatingDiary.make(), true),
+        (CreatingDiary.make(mainText: "edited message"), true),
+        (CreatingDiary.make(goals: [
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 3, setCount: 3)
+        ]), true),
+        (CreatingDiary.make(tags: [
+            .init(id: CreatingDiary.defaultTag.id,
+                  tagName: CreatingDiary.defaultTag.tagName,
+                  isSelected: true)
+        ]), true),
+        (Optional(nilLiteral: ()), false),
+        (CreatingDiary.make(title: ""), false),
+        (CreatingDiary.make(mainText: ""), false),
+        (CreatingDiary.make(goals: []), false)
+    ])
+    func 新規日記作成時にタイトルと本文と目標が設定されている場合は保存可能となる(
+        inputEditedDiary: CreatingDiary?,
+        expected: Bool
+    ) throws {
+        
+        let sut = CreatingDiaryUseCase(
+            initial: .initial,
+            edited: inputEditedDiary
+        )
+        
+        let result = sut.canSave
+        
+        #expect(result == expected)
+    }
+}
+
+extension CreatingDiaryUseCaseTest.EditCase {
+    
+    @Test
+    func 編集前のタイトルと異なるタイトルが入力された場合は変更を受け付ける() throws {
+        
+        let initial = CreatingDiary.make()
+        let sut = CreatingDiaryUseCase(initial: initial)
+        
+        let result = sut.editTitle(title: "test(edited)")
+        
+        let expected = CreatingDiary.make(title: "test(edited)")
+        #expect(result == .title(.init(initial: initial, edited: expected)))
+    }
+    
+    @Test
+    func 編集前のタイトルと同じタイトルが入力された場合は変更を受け付けない() throws {
+        
+        let initial = CreatingDiary.make(title: "test")
+        let sut = CreatingDiaryUseCase(initial: initial)
+        
+        let result = sut.editTitle(title: "test")
+        #expect(result == .title(.init(initial: initial)))
+    }
+    
+    @Test
+    func 編集前のメッセージと異なるメッセージが入力された場合は変更を受け付ける() throws {
+        
+        let initial = CreatingDiary.make()
+        let sut = CreatingDiaryUseCase(initial: initial)
+        
+        let result = sut.editMainText(mainText: "test message(edited)")
+        
+        let expected = CreatingDiary.make(mainText: "test message(edited)")
+        #expect(result == .mainText(.init(initial: initial, edited: expected)))
+    }
+    
+    @Test
+    func 編集前のメッセージと同じメッセージが入力された場合は変更を受け付けない() throws {
+        
+        let initial = CreatingDiary.make(mainText: "test message")
+        let sut = CreatingDiaryUseCase(initial: initial)
+        
+        let result = sut.editMainText(mainText: "test message")
+        #expect(result == .mainText(.init(initial: initial)))
+    }
+    
+    @Test
+    func 新しい目標が入力された場合は変更を受け付ける() throws {
+        
+        let initialGoals: [Goal] = [
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 3, setCount: 3)
+        ]
+        let initial = CreatingDiary.make(goals: initialGoals)
+        let sut = CreatingDiaryUseCase(initial: initial)
+        
+        let newGoal = Goal(id: UUID(), trainingType: .benchPress, numberOfSets: 3, setCount: 3)
+        let result = sut.addGoal(newGoal)
+        
+        let expected = CreatingDiary.make(goals: initialGoals + [newGoal])
+        #expect(result == .goals(.init(initial: initial, edited: expected)))
+    }
+    
+    @Test
+    func 編集前の目標と異なる目標が入力された場合は変更を受け付ける() throws {
+        
+        let initialGoals: [Goal] = [
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 3, setCount: 3)
+        ]
+        let initial = CreatingDiary.make(goals: initialGoals)
+        let sut = CreatingDiaryUseCase(initial: initial)
+        
+        let result = sut.addGoal(.init(
+            id: initialGoals[0].id,
+            trainingType: .abs,
+            numberOfSets: 3,
+            setCount: 2
+        ))
+        
+        let expected = CreatingDiary.make(goals: [
+            .init(
+                id: initialGoals[0].id,
+                trainingType: .abs,
+                numberOfSets: 3,
+                setCount: 2
+            )
+         ])
+        #expect(result == .goals(.init(initial: initial, edited: expected)))
+    }
+    
+    @Test
+    func 編集前の目標と同じ目標が入力された場合は変更を受け付けない() throws {
+        
+        let initialGoals: [Goal] = [
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 3, setCount: 3)
+        ]
+        let initial = CreatingDiary.make(goals: initialGoals)
+        let sut = CreatingDiaryUseCase(initial: initial)
+        
+        let result = sut.addGoal(initialGoals[0])
+        
+        #expect(result == .goals(.init(initial: initial)))
+    }
+    
+    @Test
+    func タグを選択すると選択状態が切り替わる() throws {
+        
+        let initialTags: [MachoView.Tag] = [
+            .init(id: UUID(), tagName: "test1", isSelected: true),
+        ]
+        let initial = CreatingDiary.make(tags: initialTags)
+        let sut = CreatingDiaryUseCase(initial: initial)
+        
+        let result = sut.selectTag(initialTags[0])
+        
+        let expected = CreatingDiary.make(tags: [
+            .init(id: initialTags[0].id,
+                  tagName: initialTags[0].tagName,
+                  isSelected: false)
+        ])
+        #expect(result == .tags(.init(initial: initial, edited: expected)))
+    }
+    
+    @Test(arguments: [
+        CreatingDiaryUseCase(initial: .make(tags: [.init(id: TrainingTagData.fine.id, tagName: "test", isSelected: true)])),
+        CreatingDiaryUseCase(
+            initial: .make(tags: [.init(id: TrainingTagData.fine.id, tagName: "test", isSelected: true)]),
+            edited: .make(title: "edited title", tags: [.init(id: TrainingTagData.fine.id, tagName: "test", isSelected: true)])
+        ),
+    ])
+    func タグの種類に更新があると日記作成時に選択できるタグの種類にも反映される(
+        initialUseCase: CreatingDiaryUseCase
+    ) throws {
+        
+        let sut = initialUseCase
+        
+        let updatedTags: [TrainingTagData] = [
+            .init(id: TrainingTagData.fine.id, tagName: "test"),
+            .unfine
+        ]
+        let result = sut.updateTags(updatedTags.map { TagConverter.toTag($0) })
+        
+        let expectedInitialDiary = CreatingDiary.make(tags: [
+            .init(id: TrainingTagData.fine.id, tagName: "test", isSelected: true),
+            TagConverter.toTag(.unfine)
+        ])
+        let expectedEditedDiary: CreatingDiary? = if let edited = initialUseCase.edited {
+            
+            CreatingDiary.make(title: edited.title ?? "",
+                               tags: expectedInitialDiary.tags)
+        }
+        else {
+            
+            nil
+        }
+        
+        let expectedUseCase = CreatingDiaryUseCase(
+            initial: expectedInitialDiary,
+            edited: expectedEditedDiary
+        )
+        #expect(result == .tags(expectedUseCase))
+    }
+}
+
+fileprivate extension CreatingDiary {
+    
+    static let defaultDiaryId = UUID()
+    static let defaultDate = Date.create(year: 2025, month: 1, day: 1)
+    static let defaultGoal = Goal(id: UUID(),
+                                  trainingType: .abs,
+                                  numberOfSets: 3,
+                                  setCount: 3)
+    static let defaultTag = MachoView.Tag(id: UUID(),
+                                          tagName: "test",
+                                          isSelected: false)
+    
+    static func make(id: UUID? = Self.defaultDiaryId,
+                     createdAt: Date? = Self.defaultDate,
+                     title: String = "test",
+                     mainText: String = "test message",
+                     goals: [Goal] = [defaultGoal],
+                     tags: [MachoView.Tag] = [defaultTag]) -> Self {
+           
+           
+           return .init(
+               id: id,
+               createdAt: createdAt,
+               title: title,
+               mainText: mainText,
+               goals: goals,
+               tags: tags
+           )
+       }
+}


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #72 

## 概要
日記作成画面のビジネスロジックがPresentaionロジックと密結合していたので、ドメインクラスへ移譲するようにリファクタしました。

## 変更点

- 日記作成画面のビジネスロジックをドメインクラスへ移譲

## 影響範囲
日記作成画面、目標設定画面

## 動作確認

- シミュレーターで日記を編集できることを確認
- シミュレーターで新規の日記を作成できることを確認
- UTが全て通ることを確認
