### PR TITLE
[AD1.0] 編集画面にトレーニング終了ボタンを表示するように修正

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -25,7 +25,8 @@ struct DiaryCreationFeature: Sendable {
         var goals: [Goal] = []
         var animationsRunning = false
         var textFieldFocusState: DiaryCreationTextFieldFocus?
-        var isEnableStartButton: Bool { useCase.canSave }
+        var isEnableSaveButton: Bool { useCase.canSave }
+        var isEnableFinishButton: Bool { useCase.canFinish }
         var isEditMode: Bool { useCase.isEditMode }
         
         @Presents var destination: Destination.State?
@@ -43,6 +44,7 @@ struct DiaryCreationFeature: Sendable {
         case messageTextChange(String)
         case trainingStartButtonTapped
         case trainingSaveButtonTapped
+        case trainingFinishButtonTapped
         case animateStartButton
         case destination(PresentationAction<Destination.Action>)
         case tappedAddingTagButton
@@ -112,6 +114,17 @@ struct DiaryCreationFeature: Sendable {
                     .send(.animateStartButton),
                     .run { [state] _ in
                         
+                        await saveDiary(diary: state.useCase.edited)
+                    },
+                    popToPrev()
+                )
+                
+            case .trainingFinishButtonTapped:
+                return .concatenate(
+                    .send(.animateStartButton),
+                    .run { [state] _ in
+                        
+                        // TODO: トレーニングを終了状態に更新する
                         await saveDiary(diary: state.useCase.edited)
                     },
                     popToPrev()

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -128,18 +128,12 @@ private extension DiaryCreationView {
             .scrollIndicators(.hidden)
             
             if store.isEditMode {
-                
-                editButton(animationsRunning: store.animationsRunning, parentSize: parentSize) {
-                    
-                    store.send(.trainingSaveButtonTapped)
-                }
+ 
+                editModeSaveButtonArea()
             }
             else {
                 
-                startButton(animationsRunning: store.animationsRunning, parentSize: parentSize) {
-                    
-                    store.send(.trainingStartButtonTapped)
-                }
+                startButton()
             }
             
             Spacer()
@@ -309,42 +303,67 @@ private extension DiaryCreationView {
                alignment: .leading)
     }
     
-    func editButton(animationsRunning: Bool,
-                    parentSize: CGSize,
+    func editModeSaveButtonArea() -> some View {
+        
+        VStack(spacing: 16) {
+            finishButton() // TODO: トレーニングが終了している日記には表示しないようにする
+            editButton()
+        }
+    }
+    
+    func finishButton() -> some View {
+        
+        saveButton(title: "Finish Training!!",
+                   iconName: "flame.fill",
+                   color: .red,
+                   isEnable: store.isEnableFinishButton) {
+            
+            store.send(.trainingSaveButtonTapped)
+        }
+    }
+    
+    func editButton() -> some View {
+        
+        saveButton(title: "Continue Training",
+                   iconName: "figure.run",
+                   color: .orange,
+                   isEnable: store.isEnableSaveButton) {
+            
+            store.send(.trainingSaveButtonTapped)
+        }
+    }
+    
+    func startButton() -> some View {
+        
+        saveButton(title: "Training Start!",
+                   iconName: "figure.run.square.stack",
+                   color: .orange,
+                   isEnable: store.isEnableSaveButton) {
+            
+            store.send(.trainingStartButtonTapped)
+        }
+    }
+    
+    func saveButton(title: String,
+                    iconName: String,
+                    color: Color,
+                    isEnable: Bool,
                     action: @escaping () -> Void) -> some View {
         
         Button(action: action, label: {
             HStack {
-                Image(systemName: "figure.run.square.stack")
+                Image(systemName: iconName)
                     .font(.system(size: 24))
-                    .symbolEffect(.bounce, value: animationsRunning)
-                Text("Save")
+                    .symbolEffect(.bounce, value: store.animationsRunning)
+                Text(title)
                     .font(.system(size: textSize, weight: .bold))
             }
-            .frame(maxWidth: ViewUtil.calcWidth(size: parentSize, horizontalPadding: horizontalPadding),
+            .frame(maxWidth: .infinity,
                    minHeight: startButtonHeight)
         })
-        .fillButtonStyle(backgroundColor: store.isEnableStartButton ? .orange : .gray)
-        .disabled(!store.isEnableStartButton)
-    }
-    
-    func startButton(animationsRunning: Bool,
-                     parentSize: CGSize,
-                     action: @escaping () -> Void) -> some View {
-        
-        Button(action: action, label: {
-            HStack {
-                Image(systemName: "figure.run.square.stack")
-                    .font(.system(size: 24))
-                    .symbolEffect(.bounce, value: animationsRunning)
-                Text("Training Start!")
-                    .font(.system(size: textSize, weight: .bold))
-            }
-            .frame(maxWidth: ViewUtil.calcWidth(size: parentSize, horizontalPadding: horizontalPadding),
-                   minHeight: startButtonHeight)
-        })
-        .fillButtonStyle(backgroundColor: store.isEnableStartButton ? .orange : .gray)
-        .disabled(!store.isEnableStartButton)
+        .fillButtonStyle(backgroundColor: isEnable ? color : .gray)
+        .disabled(!isEnable)
+        .padding(.horizontal, horizontalPadding)
     }
 }
 

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -13,7 +13,6 @@ struct DiaryCreationView: View {
     // MARK: - Store
     
     @Bindable private var store: StoreOf<DiaryCreationFeature>
-    @State private var animationsRunning = false
     @FocusState private var textFieldFocusState: DiaryCreationTextFieldFocus?
     
     // MARK: - initialize

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
@@ -28,6 +28,11 @@ struct CreatingDiaryUseCase: Equatable {
         return edited?.canSave ?? false
     }
     
+    var canFinish: Bool {
+        
+        return edited?.canSave ?? initial.canSave
+    }
+    
     func editTitle(title: String) -> EditEvent {
         
         return .title(edit(title: title))

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Goal.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Goal.swift
@@ -15,6 +15,8 @@ struct Goal: Equatable, Identifiable {
     var trainingType: TrainingTypeData
     var numberOfSets: Int
     var setCount: Int
+    var actualNumberOfSets: Int
+    var actualSetCount: Int
     
     var entity: TrainingContentData {
         
@@ -22,7 +24,22 @@ struct Goal: Equatable, Identifiable {
                      trainingType: trainingType,
                      goalNumberOfSets: numberOfSets,
                      goalSetCount: setCount,
-                     actualNumberOfSets: nil,
-                     actualSetCount: nil)
+                     actualNumberOfSets: actualNumberOfSets,
+                     actualSetCount: actualSetCount)
+    }
+    
+    init(id: UUID,
+         trainingType: TrainingTypeData,
+         numberOfSets: Int,
+         setCount: Int,
+         actualNumberOfSets: Int = 0,
+         actualSetCount: Int = 0) {
+        
+        self.id = id
+        self.trainingType = trainingType
+        self.numberOfSets = numberOfSets
+        self.setCount = setCount
+        self.actualNumberOfSets = actualNumberOfSets
+        self.actualSetCount = actualSetCount
     }
 }

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/Entity/CreatingDiaryUseCaseTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/Entity/CreatingDiaryUseCaseTest.swift
@@ -76,6 +76,37 @@ extension CreatingDiaryUseCaseTest.CanSaveCase {
         
         #expect(result == expected)
     }
+    
+    @Test(arguments: [
+        (CreatingDiary.make(), true),
+        (CreatingDiary.make(mainText: "edited message"), true),
+        (CreatingDiary.make(goals: [
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 3, setCount: 3)
+        ]), true),
+        (CreatingDiary.make(tags: [
+            .init(id: CreatingDiary.defaultTag.id,
+                  tagName: CreatingDiary.defaultTag.tagName,
+                  isSelected: true)
+        ]), true),
+        (Optional(nilLiteral: ()), true),
+        (CreatingDiary.make(title: ""), false),
+        (CreatingDiary.make(mainText: ""), false),
+        (CreatingDiary.make(goals: []), false)
+    ])
+    func タイトルと本文と目標が設定されている場合はトレーニング終了可能となる(
+        inputEditedDiary: CreatingDiary?,
+        expected: Bool
+    ) throws {
+        
+        let sut = CreatingDiaryUseCase(
+            initial: CreatingDiary.make(),
+            edited: inputEditedDiary
+        )
+        
+        let result = sut.canFinish
+        
+        #expect(result == expected)
+    }
 }
 
 extension CreatingDiaryUseCaseTest.EditCase {


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #72 

## 概要
作成した日記のトレーニングに対して、トレーニングを終了させるイベントが必要になるので、一旦ボタンだけ実装しました。
トレーニング終了ボタンは以下条件で押下可能になる。
- タイトルが入力されていること
- メッセージが入力されていること
- 目標が設定されていること

## 変更点

- 終了ボタンを表示するようにした
- 単体テストに終了ボタン利用可能判定メソッドのケースを追加

## 影響範囲
日記作成画面

## 動作確認

- シミュレーターで編集画面を開いたときに終了ボタンが押下可能な状態であることを確認
- UTが全て通ること
