### PR TITLE
[AD1.0] 日記のトレーニングを終了できるようにする

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -342,7 +342,8 @@ extension DiaryCreationFeature.State {
                                           title: diary.title,
                                           mainText: diary.mainText,
                                           goals: goals,
-                                          tags: tags)
+                                          tags: tags,
+                                          isFinished: diary.endTime != nil)
         
         useCase = .init(initial: creatingDiary)
         titleText = diary.title

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -27,6 +27,7 @@ struct DiaryCreationFeature: Sendable {
         var textFieldFocusState: DiaryCreationTextFieldFocus?
         var isEnableSaveButton: Bool { useCase.canSave }
         var isEnableFinishButton: Bool { useCase.canFinish }
+        var shouldShowFinishButton: Bool { useCase.shouldShowFinishButton }
         var isEditMode: Bool { useCase.isEditMode }
         
         @Presents var destination: Destination.State?

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -100,36 +100,17 @@ struct DiaryCreationFeature: Sendable {
                 state = updateCreatingDiaryState(state.useCase.editMainText(mainText: text), state: state)
                 return .none
                 
-            case .trainingStartButtonTapped:
-                return .concatenate(
-                    .send(.animateStartButton),
-                    .run { [state] _ in
-                        
-                        await saveDiary(diary: state.useCase.edited)
-                    },
-                    popToPrev()
-                )
-                
-            case .trainingSaveButtonTapped:
-                return .concatenate(
-                    .send(.animateStartButton),
-                    .run { [state] _ in
-                        
-                        await saveDiary(diary: state.useCase.edited)
-                    },
-                    popToPrev()
-                )
+            case .trainingStartButtonTapped, .trainingSaveButtonTapped:
+                return saveEffect { [target = state.useCase.edited] in
+                    
+                    await saveDiary(diary: target)
+                }
                 
             case .trainingFinishButtonTapped:
-                return .concatenate(
-                    .send(.animateStartButton),
-                    .run { [state] _ in
-                        
-                        // TODO: トレーニングを終了状態に更新する
-                        await saveDiary(diary: state.useCase.edited)
-                    },
-                    popToPrev()
-                )
+                return saveEffect { [finishTarget = state.useCase.finishTarget] in
+                    
+                    await finishTraining(diary: finishTarget)
+                }
                 
             case .animateStartButton:
                 withAnimation(.easeIn(duration: 0.5)) {
@@ -219,10 +200,26 @@ private extension DiaryCreationFeature {
         }
     }
     
+    func saveEffect(saveAction: @escaping () async -> Void) -> Effect<Self.Action> {
+        
+        return .concatenate(
+            .send(.animateStartButton),
+            .run { _ in await saveAction() },
+            popToPrev()
+        )
+    }
+    
     func saveDiary(diary: CreatingDiary?) async {
         
         guard let diary,
               let entity = convertToDbEntity(diary: diary) else { return }
+        _ = await diaryListFetchApi.add(entity)
+    }
+    
+    func finishTraining(diary: CreatingDiary?) async {
+        
+        guard let diary,
+              let entity = convertToDbEntity(diary: diary.finish()) else { return }
         _ = await diaryListFetchApi.add(entity)
     }
     
@@ -245,7 +242,7 @@ private extension DiaryCreationFeature {
                      goals: diary.goals.map(\.entity),
                      tags: diary.tags.filter(\.isSelected).map { TagConverter.toEntity($0) },
                      startTime: createdAt,
-                     endTime: nil)
+                     endTime: diary.isFinished ? date() : nil)
     }
     
     func popToPrev() -> Effect<Self.Action> {

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -305,7 +305,9 @@ private extension DiaryCreationView {
     func editModeSaveButtonArea() -> some View {
         
         VStack(spacing: 16) {
-            finishButton() // TODO: トレーニングが終了している日記には表示しないようにする
+            if store.shouldShowFinishButton {
+                finishButton()
+            }
             editButton()
         }
     }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -319,7 +319,7 @@ private extension DiaryCreationView {
                    color: .red,
                    isEnable: store.isEnableFinishButton) {
             
-            store.send(.trainingSaveButtonTapped)
+            store.send(.trainingFinishButtonTapped)
         }
     }
     

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
@@ -51,6 +51,17 @@ struct CreatingDiary: Equatable {
                      tags: tags ?? self.tags,
                      isFinished: isFinished)
     }
+    
+    func finish() -> Self {
+        
+        return .init(id: id,
+                     createdAt: createdAt,
+                     title: title,
+                     mainText: mainText,
+                     goals: goals,
+                     tags: tags,
+                     isFinished: true)
+    }
 }
 
 extension CreatingDiary {

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
@@ -28,6 +28,11 @@ struct CreatingDiary: Equatable {
         return true
     }
     
+    var canFinish: Bool {
+        
+        return canSave && !isFinished
+    }
+    
     var isEditMode: Bool {
         
         return id != nil && createdAt != nil && canSave

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiary.swift
@@ -17,6 +17,7 @@ struct CreatingDiary: Equatable {
     let mainText: String?
     let goals: [Goal]
     let tags: [Tag]
+    let isFinished: Bool
     
     var canSave: Bool {
         
@@ -42,7 +43,8 @@ struct CreatingDiary: Equatable {
                      title: title ?? self.title,
                      mainText: mainText ?? self.mainText,
                      goals: goals ?? self.goals,
-                     tags: tags ?? self.tags)
+                     tags: tags ?? self.tags,
+                     isFinished: isFinished)
     }
 }
 
@@ -53,5 +55,6 @@ extension CreatingDiary {
                                      title: nil,
                                      mainText: nil,
                                      goals: [],
-                                     tags: [])
+                                     tags: [],
+                                     isFinished: false)
 }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
@@ -23,6 +23,11 @@ struct CreatingDiaryUseCase: Equatable {
         return initial.isEditMode
     }
     
+    var shouldShowFinishButton: Bool {
+        
+        return !initial.isFinished
+    }
+    
     var canSave: Bool {
         
         return edited?.canSave ?? false
@@ -30,7 +35,7 @@ struct CreatingDiaryUseCase: Equatable {
     
     var canFinish: Bool {
         
-        return edited?.canSave ?? initial.canSave
+        return edited?.canFinish ?? initial.canFinish
     }
     
     func editTitle(title: String) -> EditEvent {

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
@@ -38,6 +38,11 @@ struct CreatingDiaryUseCase: Equatable {
         return edited?.canFinish ?? initial.canFinish
     }
     
+    var finishTarget: CreatingDiary {
+        
+        return edited ?? initial
+    }
+    
     func editTitle(title: String) -> EditEvent {
         
         return .title(edit(title: title))

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/Entity/CreatingDiaryUseCaseTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/Entity/CreatingDiaryUseCaseTest.swift
@@ -12,6 +12,7 @@ import Testing
 
 @testable import MachoView
 
+@Suite("日記作成・編集のユースケーステスト")
 struct CreatingDiaryUseCaseTest {
     
     @Suite("保存可能判定処理のケース")
@@ -106,6 +107,31 @@ extension CreatingDiaryUseCaseTest.CanSaveCase {
         let result = sut.canFinish
         
         #expect(result == expected)
+    }
+    
+    @Test(arguments: [
+        CreatingDiaryUseCase.init(initial: .make()),
+        .init(initial: .make(), edited: .make(title: "edit")),
+        .init(initial: .make(), edited: .make(title: "edit", isFinished: true))
+    ])
+    func 日記のトレーニングが終了していなければ終了ボタンを表示する(useCase: CreatingDiaryUseCase) throws {
+                
+        let result = useCase.shouldShowFinishButton
+        
+        #expect(result)
+    }
+    
+    @Test(arguments: [
+        CreatingDiaryUseCase.init(initial: .make(isFinished: true)),
+        .init(initial: .make(isFinished: true), edited: .make(title: "edit")),
+        .init(initial: .make(isFinished: true), edited: .make(title: "edit", isFinished: true)),
+        .init(initial: .make(isFinished: true), edited: .make(title: "edit"))
+    ])
+    func 日記のトレーニングが終了している場合は終了ボタンは表示しない(useCase: CreatingDiaryUseCase) throws {
+                
+        let result = useCase.shouldShowFinishButton
+        
+        #expect(!result)
     }
 }
 
@@ -289,7 +315,8 @@ fileprivate extension CreatingDiary {
                      title: String = "test",
                      mainText: String = "test message",
                      goals: [Goal] = [defaultGoal],
-                     tags: [MachoView.Tag] = [defaultTag]) -> Self {
+                     tags: [MachoView.Tag] = [defaultTag],
+                     isFinished: Bool = false) -> Self {
            
            
            return .init(
@@ -298,7 +325,8 @@ fileprivate extension CreatingDiary {
                title: title,
                mainText: mainText,
                goals: goals,
-               tags: tags
+               tags: tags,
+               isFinished: isFinished
            )
        }
 }


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #72 

## 概要
終了ボタンを押下すると、日記の終了日を設定して日記のトレーニングを終了するようにしました。
終了ボタンは日記のトレーニングがすでに終了済みの場合は表示しないようにしました。

## 変更点

- 日記作成画面の終了ボタンを押下するとトレーニングを終了するように修正
- 日記作成画面の終了ボタンはトレーニングがすでに終了している場合は表示しないように修正
- 終了ボタンを表示するかどうかの判定処理の単体テストを追加

## 影響範囲
日記作成/編集画面

## 動作確認

- シミュレーターで日記作成画面で終了ボタン押下で再度その日記の編集画面を開くと、終了ボタンが表示されないことを確認
- UTが全て通ることを確認
