### PR TITLE
[AD1.0] トレーニングの実際のセット数を編集できるようにする

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -54,8 +54,8 @@ struct DiaryCreationFeature: Sendable {
         case tappedAddingGoalButton
         case deletedGoal(Goal)
         case editingGoal(Goal)
-        case tappedAddActualSetButton
-        case tappedMinusActualSetButton
+        case tappedAddActualSetButton(Goal)
+        case tappedMinusActualSetButton(Goal)
         case didChangeFocusState(DiaryCreationTextFieldFocus?)
         case tappedOutsideOfKeyboard
         case tappedNavigationBackButton
@@ -159,10 +159,18 @@ struct DiaryCreationFeature: Sendable {
                 ))
                 return .none
                 
-            case .tappedAddActualSetButton:
+            case .tappedAddActualSetButton(let goal):
+                state = updateCreatingDiaryState(
+                    state.useCase.incrementActualSetCount(of: goal),
+                    state: state
+                )
                 return .none
                 
-            case .tappedMinusActualSetButton:
+            case .tappedMinusActualSetButton(let goal):
+                state = updateCreatingDiaryState(
+                    state.useCase.decrementActualSetCount(of: goal),
+                    state: state
+                )
                 return .none
                 
             case .didChangeFocusState(let newState):

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -347,7 +347,8 @@ extension DiaryCreationFeature.State {
             return .init(id: $0.id,
                          trainingType: trainingType,
                          numberOfSets: $0.goalNumberOfSets,
-                         setCount: $0.goalSetCount)
+                         setCount: $0.goalSetCount,
+                         actualSetCount: $0.actualSetCount ?? .zero)
         }
         let tags: [Tag] = diary.tags.map { TagConverter.toTag($0, isSelected: true) }
         let creatingDiary = CreatingDiary(id: diary.id,

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -54,6 +54,8 @@ struct DiaryCreationFeature: Sendable {
         case tappedAddingGoalButton
         case deletedGoal(Goal)
         case editingGoal(Goal)
+        case tappedAddActualSetButton
+        case tappedMinusActualSetButton
         case didChangeFocusState(DiaryCreationTextFieldFocus?)
         case tappedOutsideOfKeyboard
         case tappedNavigationBackButton
@@ -155,6 +157,12 @@ struct DiaryCreationFeature: Sendable {
                     setCount: goal.setCount,
                     isEnableSaveButton: true
                 ))
+                return .none
+                
+            case .tappedAddActualSetButton:
+                return .none
+                
+            case .tappedMinusActualSetButton:
                 return .none
                 
             case .didChangeFocusState(let newState):

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -263,6 +263,14 @@ private extension DiaryCreationView {
                         .font(.system(size: 16))
                         .foregroundStyle(.white)
                 }
+                Spacer()
+                Text("達成セット: \(goal.actualSetCount)")
+                editActualSetCountButton(iconName: "plus") {
+                    store.send(.tappedAddActualSetButton(goal))
+                }
+                editActualSetCountButton(iconName: "minus") {
+                    store.send(.tappedMinusActualSetButton(goal))
+                }
             }
             .clipped()
             .listRowBackground(Color.indigo)
@@ -286,6 +294,17 @@ private extension DiaryCreationView {
         .listRowSpacing(10.0)
         .scrollDisabled(true)
         .frame(minHeight: (goalCellHeight + goalCellMargin) * CGFloat(store.goals.count))
+    }
+    
+    func editActualSetCountButton(iconName: String, action: @escaping () -> Void) -> some View {
+        Button {
+            action()
+        } label: {
+            Image(systemName: iconName)
+                .frame(width: 16, height: 16)
+                .padding(8)
+        }
+        .fillButtonStyle(cornerRadius: 12)
     }
     
     func addingButton(title: String, parentSize: CGSize, action: @escaping () -> Void) -> some View {

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -264,12 +264,16 @@ private extension DiaryCreationView {
                         .foregroundStyle(.white)
                 }
                 Spacer()
-                Text("達成セット: \(goal.actualSetCount)")
-                editActualSetCountButton(iconName: "plus") {
-                    store.send(.tappedAddActualSetButton(goal))
-                }
-                editActualSetCountButton(iconName: "minus") {
-                    store.send(.tappedMinusActualSetButton(goal))
+                if store.isEditMode {
+                    HStack(spacing: 8) {
+                        Text("達成セット: \(goal.actualSetCount)")
+                        editActualSetCountButton(iconName: "plus") {
+                            store.send(.tappedAddActualSetButton(goal))
+                        }
+                        editActualSetCountButton(iconName: "minus") {
+                            store.send(.tappedMinusActualSetButton(goal))
+                        }
+                    }
                 }
             }
             .clipped()

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
@@ -76,6 +76,24 @@ struct CreatingDiaryUseCase: Equatable {
         return .goals(edit(goals: targetGoals.dropFirst(targetIndex).map(\.self)))
     }
     
+    func incrementActualSetCount(of goal: Goal) -> EditEvent {
+        
+        let targetGoals = edited?.goals ?? initial.goals
+        return .goals(edit(goals: getUpdateGoals(
+            updatedGoal: goal.incrementSet(),
+            current: targetGoals
+        )))
+    }
+    
+    func decrementActualSetCount(of goal: Goal) -> EditEvent {
+        
+        let targetGoals = edited?.goals ?? initial.goals
+        return .goals(edit(goals: getUpdateGoals(
+            updatedGoal: goal.decrementSet(),
+            current: targetGoals
+        )))
+    }
+    
     func selectTag(_ tag: Tag) -> EditEvent {
         
         let updateTags = edited?.tags ?? initial.tags
@@ -167,5 +185,17 @@ private extension CreatingDiaryUseCase {
             
             return .init(initial: initial, edited: nil)
         }
+    }
+    
+    func getUpdateGoals(updatedGoal: Goal, current: [Goal]) -> [Goal] {
+        
+        var updatedGoals = current
+        guard let targetIndex = updatedGoals.firstIndex(where: { $0.id == updatedGoal.id }) else {
+            
+            return current
+        }
+        
+        updatedGoals[targetIndex] = updatedGoal
+        return updatedGoals
     }
 }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Goal.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Goal.swift
@@ -15,7 +15,6 @@ struct Goal: Equatable, Identifiable {
     var trainingType: TrainingTypeData
     var numberOfSets: Int
     var setCount: Int
-    var actualNumberOfSets: Int
     var actualSetCount: Int
     
     var entity: TrainingContentData {
@@ -24,7 +23,7 @@ struct Goal: Equatable, Identifiable {
                      trainingType: trainingType,
                      goalNumberOfSets: numberOfSets,
                      goalSetCount: setCount,
-                     actualNumberOfSets: actualNumberOfSets,
+                     actualNumberOfSets: nil,
                      actualSetCount: actualSetCount)
     }
     
@@ -32,14 +31,12 @@ struct Goal: Equatable, Identifiable {
          trainingType: TrainingTypeData,
          numberOfSets: Int,
          setCount: Int,
-         actualNumberOfSets: Int = 0,
          actualSetCount: Int = 0) {
         
         self.id = id
         self.trainingType = trainingType
         self.numberOfSets = numberOfSets
         self.setCount = setCount
-        self.actualNumberOfSets = actualNumberOfSets
         self.actualSetCount = actualSetCount
     }
     

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Goal.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/Goal.swift
@@ -42,4 +42,22 @@ struct Goal: Equatable, Identifiable {
         self.actualNumberOfSets = actualNumberOfSets
         self.actualSetCount = actualSetCount
     }
+    
+    func incrementSet() -> Self {
+        
+        return .init(id: id,
+                     trainingType: trainingType,
+                     numberOfSets: numberOfSets,
+                     setCount: setCount,
+                     actualSetCount: actualSetCount + 1)
+    }
+    
+    func decrementSet() -> Self {
+        
+        return .init(id: id,
+                     trainingType: trainingType,
+                     numberOfSets: numberOfSets,
+                     setCount: setCount,
+                     actualSetCount: actualSetCount == .zero ? .zero : actualSetCount - 1)
+    }
 }

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/Entity/CreatingDiaryUseCaseTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/Entity/CreatingDiaryUseCaseTest.swift
@@ -239,6 +239,54 @@ extension CreatingDiaryUseCaseTest.EditCase {
     }
     
     @Test
+    func 達成したセット数を1セット増やす() throws {
+        
+        let initialGoals: [Goal] = [
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 3, setCount: 3),
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 2, setCount: 4),
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 99, setCount: 3)
+        ]
+        let initial = CreatingDiary.make(goals: initialGoals)
+        let sut = CreatingDiaryUseCase(initial: initial)
+        
+        let result = sut.incrementActualSetCount(of: initialGoals[1])
+        
+        let expected = CreatingDiary.make(goals: [
+            initialGoals[0],
+            .init(id: initialGoals[1].id,
+                  trainingType: initialGoals[1].trainingType,
+                  numberOfSets: initialGoals[1].numberOfSets,
+                  setCount: initialGoals[1].setCount, actualSetCount: 1),
+            initialGoals[2]
+        ])
+        #expect(result == .goals(.init(initial: initial, edited: expected)))
+    }
+    
+    @Test
+    func 達成したセット数を1セット減らす() throws {
+        
+        let initialGoals: [Goal] = [
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 3, setCount: 3, actualSetCount: 90),
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 2, setCount: 4),
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 99, setCount: 3)
+        ]
+        let initial = CreatingDiary.make(goals: initialGoals)
+        let sut = CreatingDiaryUseCase(initial: initial)
+        
+        let result = sut.decrementActualSetCount(of: initialGoals[0])
+        
+        let expected = CreatingDiary.make(goals: [
+            .init(id: initialGoals[0].id,
+                  trainingType: initialGoals[0].trainingType,
+                  numberOfSets: initialGoals[0].numberOfSets,
+                  setCount: initialGoals[0].setCount, actualSetCount: 89),
+            initialGoals[1],
+            initialGoals[2]
+        ])
+        #expect(result == .goals(.init(initial: initial, edited: expected)))
+    }
+    
+    @Test
     func タグを選択すると選択状態が切り替わる() throws {
         
         let initialTags: [MachoView.Tag] = [


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #72 

## 概要
日記の編集画面でトレーニングの実行セット数を増減させることができるように修正しました。
実行セット数の増減を行うボタンは、新規日記作成時には表示しないようにしています。

各セット毎の回数の入力する機能は一旦実装してません。
ユースケースを想像すると、大体1セット単位で入力したほうが楽で、1セット毎の回数をポチポチするのはめんどくさそうなので、細かく設定できるメリットよりもユーザー体験を落とすデメリットが勝つ気がしたからです。

## 変更点

- 日記編集画面に実行セット数を増減させるボタンを追加
- 実行セット数を増減させるケースのテスト追加

## 影響範囲
日記作成/編集画面

## 動作確認

- シミュレーターで日記編集時に目標の部分に実行セット数を増減できるボタンが表示されていたこと
  - 増加ボタン押下で実行セット数が1増えること
  - 減少ボタン押下で実行セット数が1減ること
  - 実行セット数0の状態で減少ボタン押下すると0のままであること
  - 実行セット数を増加させた状態で保存すると、実行達成状況に応じて日記リストの達成状況が反映されていること
- UTが全て通ること
