### PR TITLE
[AD1.0] 日記作成画面で目標が削除できない不具合の修正

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationFeature.swift
@@ -145,7 +145,8 @@ struct DiaryCreationFeature: Sendable {
             case .deletedGoal(let goal):
                 withAnimation(.easeIn(duration: 0.5)) {
                     
-                    state = updateCreatingDiaryState(state.useCase.removeGoal(goal), state: state)
+                    state = updateCreatingDiaryState(state.useCase.removeGoal(goal),
+                                                     state: state)
                 }
                 return .none
                 

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/Entity/CreatingDiaryUseCase.swift
@@ -67,13 +67,14 @@ struct CreatingDiaryUseCase: Equatable {
     
     func removeGoal(_ goal: Goal) -> EditEvent {
         
-        let targetGoals = edited?.goals ?? initial.goals
-        guard let targetIndex = targetGoals.firstIndex(of: goal) else {
+        var targetGoals = edited?.goals ?? initial.goals
+        guard let targetIndex = targetGoals.firstIndex(where: { $0.id == goal.id }) else {
             
             return .goals(edit())
         }
         
-        return .goals(edit(goals: targetGoals.dropFirst(targetIndex).map(\.self)))
+        targetGoals.remove(at: targetIndex)
+        return .goals(edit(goals: targetGoals))
     }
     
     func incrementActualSetCount(of goal: Goal) -> EditEvent {

--- a/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/Entity/CreatingDiaryUseCaseTest.swift
+++ b/Macho/MachoFramework/Tests/MachoFrameworkTests/Views/DiaryCreation/Entity/CreatingDiaryUseCaseTest.swift
@@ -239,6 +239,22 @@ extension CreatingDiaryUseCaseTest.EditCase {
     }
     
     @Test
+    func 指定した目標を削除する() async throws {
+        
+        let initialGoals: [Goal] = [
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 3, setCount: 3),
+            .init(id: UUID(), trainingType: .abs, numberOfSets: 1, setCount: 1)
+        ]
+        let initial = CreatingDiary.make(goals: initialGoals)
+        let sut = CreatingDiaryUseCase(initial: initial)
+        
+        let result = sut.removeGoal(initialGoals[1])
+        
+        let expected = CreatingDiary.make(goals: [initialGoals[0]])
+        #expect(result == .goals(.init(initial: initial, edited: expected)))
+    }
+    
+    @Test
     func 達成したセット数を1セット増やす() throws {
         
         let initialGoals: [Goal] = [


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #72 

## 概要
編集画面の実装対応で目標が削除できなくなっていたので修正しました。

## 変更点

- 目標削除ロジックを修正
- 日記作成のテストに目標削除のテストケースを追加

## 影響範囲
日記作成/編集画面

## 動作確認

- シミュレーターで日記作成画面で目標削除できることを確認
- UTが全て通ること
