### PR TITLE
[AD1.0] 日記作成画面でキーボード表示時にコンテンツが上によってしまいタイトルのテキストフィーが見えない問題を解消

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryCreation/DiaryCreationView.swift
@@ -68,6 +68,7 @@ struct DiaryCreationView: View {
                 }
             }
         }
+        .ignoresSafeArea(.keyboard, edges: .bottom)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 NavigationButton(.back) {


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #73 

## 概要
日記作成画面でタイトルのテキストフィールドフォーカス時に、キーボード表示でコンテンツが上によってしまい、タイトルのテキストフィーが見えない問題があったので、
日記作成画面ではキーボード表示にコンテンツが上に上がらないように修正。

## 変更点

- 日記作成画面ではキーボード表示にコンテンツが上に上がらないように修正

## 影響範囲
日記作成画面

## 動作確認

- シミュレーターで日記作成画面にてキーボード表示中にコンテンツが上に上がらないことを確認
