### PR TITLE
ビルドプロセスのリンクとアプリ起動速度の最適化

### DIFF
--- a/Macho.xctestplan
+++ b/Macho.xctestplan
@@ -33,6 +33,7 @@
   },
   "testTargets" : [
     {
+      "enabled" : false,
       "target" : {
         "containerPath" : "container:Macho.xcodeproj",
         "identifier" : "D9F160FC2AE39EE60061307C",
@@ -40,6 +41,7 @@
       }
     },
     {
+      "enabled" : false,
       "target" : {
         "containerPath" : "container:Macho.xcodeproj",
         "identifier" : "D9F161062AE39EE60061307C",

--- a/Macho/Macho.xcodeproj/project.pbxproj
+++ b/Macho/Macho.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_EXPORT_SYMBOLS = NO;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -528,7 +529,13 @@
 				MERGED_BINARY_TYPE = automatic;
 				NEW_SETTING = "";
 				"NEW_SETTING[arch=*]" = "";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-all_load",
+					"-dead_strip",
+					"-Xlinker",
+					"-no_deduplicate",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = morimori.Macho;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -554,6 +561,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_EXPORT_SYMBOLS = NO;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -562,7 +570,13 @@
 				MERGEABLE_LIBRARY = NO;
 				MERGED_BINARY_TYPE = automatic;
 				NEW_SETTING = "";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-all_load",
+					"-dead_strip",
+					"-Xlinker",
+					"-no_deduplicate",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = morimori.Macho;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Macho/Macho.xcodeproj/project.pbxproj
+++ b/Macho/Macho.xcodeproj/project.pbxproj
@@ -574,8 +574,6 @@
 					"-ObjC",
 					"-all_load",
 					"-dead_strip",
-					"-Xlinker",
-					"-no_deduplicate",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = morimori.Macho;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Macho/Macho.xcodeproj/project.pbxproj
+++ b/Macho/Macho.xcodeproj/project.pbxproj
@@ -7,13 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BC46E6CC2D7B056000B7031C /* MachoFramework in Frameworks */ = {isa = PBXBuildFile; productRef = BCEA14EF2D601A630045B580 /* MachoFramework */; };
+		BC746CFC2DC8BBBF007E4222 /* MachoFramework in Frameworks */ = {isa = PBXBuildFile; productRef = BC746CFB2DC8BBBF007E4222 /* MachoFramework */; };
+		BC746CFD2DC8BBCB007E4222 /* MachoFramework in Embed Frameworks */ = {isa = PBXBuildFile; productRef = BC746CFB2DC8BBBF007E4222 /* MachoFramework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		BC746CFE2DC8BE95007E4222 /* MachoFramework in Frameworks */ = {isa = PBXBuildFile; productRef = BCEA14EF2D601A630045B580 /* MachoFramework */; };
+		BC746CFF2DC8BE95007E4222 /* MachoFramework in Frameworks */ = {isa = PBXBuildFile; productRef = BCEA14FB2D603A340045B580 /* MachoFramework */; };
 		BC98AEA22D4CA4F400EFD0BF /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = BC98AEA12D4CA4F400EFD0BF /* FirebaseCrashlytics */; };
 		BC98AEA52D4CA61500EFD0BF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BC98AEA42D4CA61500EFD0BF /* GoogleService-Info.plist */; };
 		BC98AEA72D4CA66200EFD0BF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC98AEA62D4CA66200EFD0BF /* AppDelegate.swift */; };
 		BC98AEA92D4CA71200EFD0BF /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = BC98AEA82D4CA71200EFD0BF /* FirebaseAnalytics */; };
-		BCEA14F52D601D790045B580 /* MachoFramework in Embed Frameworks */ = {isa = PBXBuildFile; productRef = BCEA14EF2D601A630045B580 /* MachoFramework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		BCEA14FC2D603A340045B580 /* MachoFramework in Frameworks */ = {isa = PBXBuildFile; productRef = BCEA14FB2D603A340045B580 /* MachoFramework */; };
 		D9F160F12AE39EE40061307C /* MachoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F160F02AE39EE40061307C /* MachoApp.swift */; };
 		D9F160F52AE39EE60061307C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D9F160F42AE39EE60061307C /* Assets.xcassets */; };
 		D9F160F82AE39EE60061307C /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D9F160F72AE39EE60061307C /* Preview Assets.xcassets */; };
@@ -46,7 +47,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BCEA14F52D601D790045B580 /* MachoFramework in Embed Frameworks */,
+				BC746CFD2DC8BBCB007E4222 /* MachoFramework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -74,10 +75,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BC46E6CC2D7B056000B7031C /* MachoFramework in Frameworks */,
+				BC746CFF2DC8BE95007E4222 /* MachoFramework in Frameworks */,
+				BC746CFE2DC8BE95007E4222 /* MachoFramework in Frameworks */,
+				BC746CFC2DC8BBBF007E4222 /* MachoFramework in Frameworks */,
 				BC98AEA22D4CA4F400EFD0BF /* FirebaseCrashlytics in Frameworks */,
 				BC98AEA92D4CA71200EFD0BF /* FirebaseAnalytics in Frameworks */,
-				BCEA14FC2D603A340045B580 /* MachoFramework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -188,6 +190,7 @@
 				BC98AEA82D4CA71200EFD0BF /* FirebaseAnalytics */,
 				BCEA14EF2D601A630045B580 /* MachoFramework */,
 				BCEA14FB2D603A340045B580 /* MachoFramework */,
+				BC746CFB2DC8BBBF007E4222 /* MachoFramework */,
 			);
 			productName = Macho;
 			productReference = D9F160ED2AE39EE40061307C /* Macho.app */;
@@ -240,7 +243,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1500;
+				LastSwiftUpdateCheck = 1630;
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					D9F160EC2AE39EE40061307C = {
@@ -267,7 +270,7 @@
 			mainGroup = D9F160E42AE39EE40061307C;
 			packageReferences = (
 				BC98AEA02D4CA4F400EFD0BF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
-				BCEA14FA2D603A340045B580 /* XCLocalSwiftPackageReference "MachoFramework" */,
+				BC746CFA2DC8BBBF007E4222 /* XCLocalSwiftPackageReference "MachoFramework" */,
 			);
 			productRefGroup = D9F160EE2AE39EE40061307C /* Products */;
 			projectDirPath = "";
@@ -332,7 +335,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\nif [ \"$CONFIGURATION\" != \"Debug\" ]; then\n    \"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols\" \\\n        -gsp \"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleService-Info.plist\" \\\n        -p ios \"${DWARF_DSYM_FOLDER_PATH}\"\nfi\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\necho debug\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -521,6 +524,8 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MERGEABLE_LIBRARY = NO;
+				MERGED_BINARY_TYPE = automatic;
 				NEW_SETTING = "";
 				"NEW_SETTING[arch=*]" = "";
 				OTHER_LDFLAGS = "-ObjC";
@@ -554,6 +559,8 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MERGEABLE_LIBRARY = NO;
+				MERGED_BINARY_TYPE = automatic;
 				NEW_SETTING = "";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = morimori.Macho;
@@ -682,7 +689,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		BCEA14FA2D603A340045B580 /* XCLocalSwiftPackageReference "MachoFramework" */ = {
+		BC746CFA2DC8BBBF007E4222 /* XCLocalSwiftPackageReference "MachoFramework" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = MachoFramework;
 		};
@@ -700,6 +707,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		BC746CFB2DC8BBBF007E4222 /* MachoFramework */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MachoFramework;
+		};
 		BC98AEA12D4CA4F400EFD0BF /* FirebaseCrashlytics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = BC98AEA02D4CA4F400EFD0BF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/Macho/Macho/AppDelegate.swift
+++ b/Macho/Macho/AppDelegate.swift
@@ -12,11 +12,10 @@ import FirebaseCore
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     
-  func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-      
-    FirebaseApp.configure()
-
-    return true
-  }
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        
+        FirebaseApp.configure()
+        return true
+    }
 }


### PR DESCRIPTION
## 関連Issue

なし

## 概要

以下WWDCのビデオを見て、リンク速度とアプリ起動時間の最適化ができそうだったので試してみました。
https://developer.apple.com/videos/play/wwdc2022/110362/
https://developer.apple.com/videos/play/wwdc2023/10268/

## 変更点

- Machoのビルド設定で、Mergeable Libraryの設定を有効にするようにしました
  - これにより、デバッグビルド時はMachoに直接依存するライブラリ/frameworkは動的ライブラリ/ frameworkとしてリンクされるようになります（ビルド時ではなく、アプリ起動時にリンクするのでビルド時間が短縮できる）
  - リリースビルド時はMachoが直接依存するライブラリ/frameworkは静的ライブラリ/frameworkとしてリンクされるようになります（ビルド時にリンクするので、アプリ起動時のリンク時間が短縮されアプリ起動のパフォーマンスが向上する）
- リンカフラグに以下を設定することで、静的リンク(ld)の性能を向上しました
  - `-all_load`：選択的リンクを行わずに依存するライブラリの全てのシンボルをリンクするようにする（選択的リンクの方が時間がかかるらしい）
  - `-dead_strip`：`-all_load`をつけると使用していないシンボルもリンクされて、アプリバイナリに含まれてしまいアプリサイズにボトルネックが発生してしまうため、この設定で使用しないシンボルを削除するようにする
  - `-no_exported_symbols`：リンカーはデフォルトでシンボル名、アドレス、およびフラグのプレフィックスエンコードをエクスポートする工程があるらしいが、メインバンドル（Macho）はこれを使用しないため、この工程をスキップする

## 影響範囲
ビルドプロセス

## 動作確認

- アプリがビルドできること

## 補足

ビルドプロセスのリンクとアプリ起動速度の改善を謳った修正ですが、現状アプリの規模が小さいので、目に見えた変化はありませんでした。せいぜい数ms程度の影響です。
ただ、今後規模が大きくなると徐々に受ける恩恵は大きくなるかなと思ったので、入れてみたという趣旨です。