### PR TITLE
【AD1.0】目標達成アイコンをキラキラさせる

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Metal/MachoShaderLibrary.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Metal/MachoShaderLibrary.swift
@@ -1,0 +1,20 @@
+//
+//  MachoFramework
+//
+//  MachoShaderLibrary.swift
+//
+//  Created by stotic-dev on 2025/05/24
+//  Copyright © Macho All rights reserved.
+//
+
+import SwiftUI
+
+extension Bundle {
+    
+    static let machoView: Bundle = .module
+}
+
+extension ShaderLibrary {
+    
+    static let machoViewLib: ShaderLibrary = .bundle(.machoView)
+}

--- a/Macho/MachoFramework/Sources/MachoView/Metal/Shader/WinIconShader.metal
+++ b/Macho/MachoFramework/Sources/MachoView/Metal/Shader/WinIconShader.metal
@@ -1,0 +1,44 @@
+//
+//  MachoFramework
+//
+//  WinIconShader.metal
+//
+//  Created by stotic-dev on 2025/05/24
+//  Copyright © Macho All rights reserved.
+//
+
+#include <metal_stdlib>
+using namespace metal;
+
+[[ stitchable ]] half4 winIconShader(
+    float2 position,
+    half4 color,
+    float2 size,
+    float time
+) {
+    constexpr float speed = 0.6;
+    constexpr float glossWidth = 0.15;
+    
+    float2 uv = position / size;
+    
+    // 擬似的な光源の向き（右上から照らす）
+    float2 lightDir = normalize(float2(1.0, 0));
+
+    // 表面の「法線」を疑似的に位置から生成
+    float2 normal = normalize(uv);
+
+    // 光源と法線の内積（0〜1の光のあたり具合）
+    float highlight = dot(normal, lightDir);
+
+    // ハイライトの動き（時間で流れる）
+    float glossAnim = fmod(time * speed, 1.0);
+    
+    // ハイライトの位置がスクリーン上をスライド
+    float glossPos = smoothstep(glossAnim - glossWidth, glossAnim, highlight)
+                   * (1.0 - smoothstep(glossAnim, glossAnim + glossWidth, highlight));
+
+    // 光沢を白く加算（やや青白い光でもOK）
+    half3 glossyColor = color.rgb + half3(1.0) * half(glossPos) * 0.5;
+
+    return half4(min(glossyColor, 1.0), color.a);
+}

--- a/Macho/MachoFramework/Sources/MachoView/Views/ViewParts/Layout/DiaryStatusIcon/AchieveIconView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/ViewParts/Layout/DiaryStatusIcon/AchieveIconView.swift
@@ -11,6 +11,7 @@ struct AchieveIconView: View {
     
     // MARK: - private property
     
+    @State private var startTime = Date()
     private let isAchieved: Bool
     private let size: CGFloat
     
@@ -29,10 +30,21 @@ struct AchieveIconView: View {
     // MARK: - view body
     
     var body: some View {
-        Text(isAchieved ? "Win" : "Lose")
-            .font(.system(size: size,
-                          weight: .heavy))
-            .foregroundStyle(Color.getWinOrLoseColorByIsAchieved(isAchieved))
+        TimelineView(.animation) { context in
+            Text(isAchieved ? "Win" : "Lose")
+                .font(.system(size: size,
+                              weight: .heavy))
+                .foregroundStyle(Color.getWinOrLoseColorByIsAchieved(isAchieved))
+                .visualEffect { [time = context.date.timeIntervalSince(startTime)] effect, proxy in
+                    effect
+                        .colorEffect(
+                            ShaderLibrary.machoViewLib.winIconShader(
+                                .float2(proxy.size),
+                                .float(time)
+                            )
+                        )
+                }
+        }
     }
 }
 

--- a/Macho/MachoFramework/Sources/MachoView/Views/ViewParts/Layout/DiaryStatusIcon/DiaryStatusIconView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/ViewParts/Layout/DiaryStatusIcon/DiaryStatusIconView.swift
@@ -37,6 +37,7 @@ struct DiaryStatusIconView: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: size, height: size)
+                .accessibilityHidden(true)
         case .finished(let info):
             AchieveIconView(isAchieved: info.isAchieved, size: size)
         }


### PR DESCRIPTION
## 関連Issue

- 関連Issue: #107 

## 概要
ユーザーの達成感を上るように、目標達成アイコンをキラキラさせる

## 変更点

- 目標達成アイコンにEffectを追加

## 影響範囲
目標達成アイコン

## 動作確認

- Simulatorで想定通り目標達成アイコンキラキラしていることを確認
