### PR TITLE
【AD1.0】詳細画面から編集画面へ遷移できるように修正

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/DiaryDetailFeature.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/DiaryDetailFeature.swift
@@ -19,7 +19,7 @@ struct DiaryDetailFeature {
     struct DiaryObserveCancellable: Hashable {}
     
     // MARK: - State
-        
+    
     @ObservableState
     struct State: Equatable {
         
@@ -31,18 +31,18 @@ struct DiaryDetailFeature {
         
         /// メッセージをさらに表示しているかどうか
         var isShownMoreMessage = false
-        /// 日記EntityのID
-        @ObservationStateIgnored let diaryId: UUID
+        /// 日記
+        var diary: Diary
         /// 日記のタイトル
-        private(set) var title: String
+        var title: String { diary.title }
         /// 日記のメッセージ
-        private(set) var message: String
+        var message: String { diary.mainText }
         /// 日記のタグ
-        private(set) var tags: [Tag]
-        /// 日記に設定したトレーニングの総合結果
-        private(set) var totalResult: TotalTrainingResult
+        var tags: [Tag] { diary.tags }
         /// 日記に設定したトレーニング種目毎の結果
-        private(set) var trainings: [Goal]
+        var trainings: [Goal] { diary.goals }
+        /// トレーニング結果のメタ情報
+        var totalTrainingResult: TotalTrainingResult
     }
     
     // MARK: - Action
@@ -92,13 +92,8 @@ struct DiaryDetailFeature {
     var body: some ReducerOf<Self> {
         
         Reduce { state, action in
-            
-            logger.info("Did receive action: \(action)")
-            
+                        
             switch action {
-                
-            case .navigationDestination:
-                return .none
                 
             case .onAppear:
                 return .run { send in
@@ -108,8 +103,7 @@ struct DiaryDetailFeature {
                 }
                 
             case .tappedEditButton:
-                // TODO: 編集画面ができたら正しいStateを設定する
-                state.navigationDestination = .editDiaryView(.init(contact: .init(id: .init(.zero), name: "sample")))
+                state.navigationDestination = .editDiary(.init(editTarget: state.diary))
                 return .cancel(id: DiaryObserveCancellable())
                 
             case .tappedBackNavigationButton:
@@ -126,7 +120,11 @@ struct DiaryDetailFeature {
                 return .none
                 
             case .observePublisher(.observeDiaryList(let publisher)):
-                return addObserveDiaryData(publisher: publisher, targetId: state.diaryId)
+                return addObserveDiaryData(publisher: publisher,
+                                           targetId: state.diary.id)
+                
+            case .navigationDestination:
+                return .none
             }
         }
         .ifLet(\.$navigationDestination, action: \.navigationDestination)
@@ -140,8 +138,7 @@ extension DiaryDetailFeature {
     @Reducer(state: .equatable, action: .equatable)
     enum Path {
         
-        // TODO: 編集画面ができたら変更する
-        case editDiaryView(AddContactFeature)
+        case editDiary(DiaryCreationFeature)
     }
 }
 
@@ -167,20 +164,13 @@ extension DiaryDetailFeature.State {
     
     init(diary: Diary) {
         
-        diaryId = diary.id
-        title = diary.title
-        message = diary.mainText
-        tags = diary.tags
-        totalResult = TotalTrainingResult(diary)
-        trainings = diary.goals
+        self.diary = diary
+        totalTrainingResult = TotalTrainingResult(diary)
     }
     
     mutating func updateDiary(_ diary: Diary) {
         
-        title = diary.title
-        message = diary.mainText
-        tags = diary.tags
-        totalResult = TotalTrainingResult(diary)
-        trainings = diary.goals
+        self.diary = diary
+        totalTrainingResult = TotalTrainingResult(diary)
     }
 }

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/DiaryDetailView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/DiaryDetailView.swift
@@ -76,10 +76,10 @@ struct DiaryDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle("Detail")
         .navigationDestination(item: $store.scope(
-            state: \.navigationDestination?.editDiaryView,
-            action: \.navigationDestination.editDiaryView
+            state: \.navigationDestination?.editDiary,
+            action: \.navigationDestination.editDiary
         )) {
-            AddContactView(store: $0)
+            DiaryCreationView(store: $0)
         }
         .onAppear {
             store.send(.onAppear)
@@ -105,7 +105,7 @@ private extension DiaryDetailView {
                 createTagsSectionView()
                     .padding(.horizontal, contentsHorizontalPadding)
                 createContentsDivider()
-                createTrainingResultSectionView(store.totalResult)
+                createTrainingResultSectionView(store.totalTrainingResult)
                     .padding(.horizontal, contentsHorizontalPadding)
                 createBasicDivider()
                     .padding(.vertical, resultPerTrainingSectionVerticalSpace)

--- a/Macho/MachoFramework/Tests/MachoViewTests/Views/DiaryDetail/DiaryDetailViewTest.swift
+++ b/Macho/MachoFramework/Tests/MachoViewTests/Views/DiaryDetail/DiaryDetailViewTest.swift
@@ -8,8 +8,8 @@
 import ComposableArchitecture
 import XCTest
 
-@testable import MachoView
 @testable import MachoCore
+@testable import MachoView
 @testable import RealmHelper
 
 final class DiaryDetailViewTest: XCTestCase {
@@ -29,12 +29,14 @@ final class DiaryDetailViewTest: XCTestCase {
         let mockRealm = try await RealmTestHelper.getMockRealm()
         let mockClient = await DiaryEntityClient.getMockClient(realm: mockRealm, initialValue: [])
         
-        let testStore = TestStore(initialState: .init(diary: Self.sampleDiaryEntity1),
-                                  reducer: { DiaryDetailFeature() },
-                                  withDependencies: {
-            $0.diaryEntityClient = mockClient
-            $0.dismiss = .init { isDismissInvoked.setValue(true) }
-        })
+        let testStore = TestStore(
+            initialState: .init(diary: Self.sampleDiaryEntity1),
+            reducer: { DiaryDetailFeature() },
+            withDependencies: {
+                $0.diaryEntityClient = mockClient
+                $0.dismiss = .init { isDismissInvoked.setValue(true) }
+            }
+        )
         
         await testStore.send(.onAppear)
         await testStore.receive(\.observePublisher)
@@ -63,20 +65,21 @@ final class DiaryDetailViewTest: XCTestCase {
         
         let mockRealm = try await RealmTestHelper.getMockRealm()
         let mockClient = await DiaryEntityClient.getMockClient(realm: mockRealm, initialValue: [])
-        let testStore = TestStore(initialState: DiaryDetailFeature.State(diary: Self.sampleDiaryEntity1),
-                                  reducer: { DiaryDetailFeature() },
-                                  withDependencies: {
-            
-            $0.diaryEntityClient = mockClient
-        })
+        let testStore = TestStore(
+            initialState: DiaryDetailFeature.State(diary: Self.sampleDiaryEntity1),
+            reducer: { DiaryDetailFeature() },
+            withDependencies: {
+                
+                $0.diaryEntityClient = mockClient
+            }
+        )
         
         await testStore.send(.onAppear)
         await testStore.receive(\.observePublisher)
         
         await testStore.send(.tappedEditButton) {
             
-            // TODO: 編集画面が実装されたら正しい値を入れる
-            $0.navigationDestination = .editDiaryView(.init(contact: .init(id: .init(.zero), name: "sample")))
+            $0.navigationDestination = .editDiary(.init(editTarget: Self.sampleDiaryEntity1))
         }
     }
     
@@ -94,13 +97,15 @@ final class DiaryDetailViewTest: XCTestCase {
         let mockRealm = try await RealmTestHelper.getMockRealm()
         let mockClient = await DiaryEntityClient.getMockClient(realm: mockRealm, initialValue: [])
         
-        let testStore = TestStore(initialState: DiaryDetailFeature.State(diary: Self.sampleDiaryEntity1),
-                                  reducer: { DiaryDetailFeature() },
-                                  withDependencies: {
-            
-            $0.diaryEntityClient = mockClient
-            $0.dismiss = .init { isDismissInvoked.setValue(true) }
-        })
+        let testStore = TestStore(
+            initialState: DiaryDetailFeature.State(diary: Self.sampleDiaryEntity1),
+            reducer: { DiaryDetailFeature() },
+            withDependencies: {
+                
+                $0.diaryEntityClient = mockClient
+                $0.dismiss = .init { isDismissInvoked.setValue(true) }
+            }
+        )
         
         await testStore.send(.onAppear)
         await testStore.receive(\.observePublisher)


### PR DESCRIPTION
## 関連Issue

- 関連Issue: 

## 概要
詳細画面から編集画面へ遷移できるようにしました

## 変更点

- 詳細画面から編集画面へ遷移する処理を仮実装から本実装に修正

## 影響範囲

詳細画面

## 動作確認

- シミュレーターで動作確認
