### PR TITLE
トレーニング中は詳細画面でトレーニングの時間を非表示にするように修正

### DIFF
--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/DiaryDetailView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/DiaryDetailView.swift
@@ -197,7 +197,7 @@ private extension DiaryDetailView {
 
 // MARK: - preview
 
-#Preview {
+#Preview("トレーニング完了") {
     let goal1 = Goal(
         id: UUID(),
         trainingType: .init(id: UUID(), name: "腹筋"),
@@ -212,11 +212,37 @@ private extension DiaryDetailView {
         id: UUID(),
         createdAt: .now,
         title: "Preview",
-        // swiftlint:disable:next line_length
-        mainText: "preview sample message\nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        mainText: "preview sample message",
         goals: [goal1],
         tags: [tag1, tag2, tag3],
         endTime: Date()
+    )
+    NavigationView {
+        DiaryDetailView(
+            store: Store(
+                initialState: DiaryDetailFeature.State(diary: initialDiaryEntity),
+                reducer: { DiaryDetailFeature() }
+            )
+        )
+    }
+}
+
+#Preview("トレーニング中") {
+    let goal1 = Goal(
+        id: UUID(),
+        trainingType: .init(id: UUID(), name: "腹筋"),
+        numberOfSets: 3,
+        setCount: 3,
+        actualSetCount: 3
+    )
+    let initialDiaryEntity = Diary(
+        id: UUID(),
+        createdAt: .now,
+        title: "Preview",
+        mainText: "preview sample message",
+        goals: [goal1],
+        tags: [],
+        endTime: nil
     )
     NavigationView {
         DiaryDetailView(

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/DiaryDetailView.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/DiaryDetailView.swift
@@ -136,8 +136,7 @@ private extension DiaryDetailView {
                                 size: achievedIconFontSize)
             VStack(alignment: .leading, spacing: .space(.small)) {
                 Text("種目数：\(trainingResult.trainingCount)")
-                Text("トレーニング開始時間：\(trainingResult.startDateDisplayText)")
-                Text("トレーニング終了時間：\(trainingResult.endDateDisplayText)")
+                Text("トレーニング日：\(trainingResult.startDateDisplayText)")
                 Text("総トレーニング時間：\(trainingResult.totalTrainingTimeDurationText)")
             }
             .font(.macho(.description))

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/Entity/TotalTrainingResult.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/Entity/TotalTrainingResult.swift
@@ -17,10 +17,6 @@ struct TotalTrainingResult: Equatable {
     
     /// トレーニング種目数
     let trainingCount: Int
-    ///　トレーニングが終了しているかどうか
-    let isFinished: Bool
-    /// 全ての目標を達成したかどうか
-    let isAchievedTotalGoal: Bool
     
     /// トレーニング開始時間
     let startDateDisplayText: String
@@ -38,8 +34,6 @@ struct TotalTrainingResult: Equatable {
         
         if case .finished(let info) = diary.status {
             
-            isFinished = true
-            isAchievedTotalGoal = info.isAchieved
             endDateDisplayText = Self.getDisplayDateText(info.endTime)
             totalTrainingTimeDurationText = Self.getTotalTrainingTimeDurationText(
                 from: diary.createdAt,
@@ -48,28 +42,18 @@ struct TotalTrainingResult: Equatable {
         }
         else {
             
-            isFinished = false
-            isAchievedTotalGoal = false
-            endDateDisplayText = Self.getDisplayDateText(nil)
-            totalTrainingTimeDurationText = Self.getTotalTrainingTimeDurationText(
-                from: diary.createdAt,
-                to: nil
-            )
+            endDateDisplayText = Self.defaultDateDisplayText
+            totalTrainingTimeDurationText = Self.defaultDateDisplayText
         }
     }
 }
 
 private extension TotalTrainingResult {
     
-    static func getDisplayDateText(_ date: Date?) -> String {
+    static func getDisplayDateText(_ date: Date) -> String {
         
-        guard let text = date?.formatted(Self.displayDateFormat,
-                                         timeZone: .autoupdatingCurrent) else {
-            
-            return Self.defaultDateDisplayText
-        }
-        
-        return text
+        return date.formatted(Self.displayDateFormat,
+                              timeZone: .autoupdatingCurrent)
     }
     
     static func getTotalTrainingTimeDurationText(from startDate: Date, to endDate: Date?) -> String {

--- a/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/Entity/TotalTrainingResult.swift
+++ b/Macho/MachoFramework/Sources/MachoView/Views/DiaryDetail/Entity/TotalTrainingResult.swift
@@ -10,19 +10,14 @@ import MachoCore
 
 struct TotalTrainingResult: Equatable {
     
-    // 時間の表示形式
-    private static let displayDateFormat: Date.MachoFormat = .localeDateTime
     // 時間が表示できない場合のデフォルト文言
     private static let defaultDateDisplayText = "まだ記録されていません"
     
     /// トレーニング種目数
     let trainingCount: Int
     
-    /// トレーニング開始時間
+    /// トレーニング開始日
     let startDateDisplayText: String
-    
-    /// トレーニング終了時間
-    let endDateDisplayText: String
     
     /// トレーニング総時間
     let totalTrainingTimeDurationText: String
@@ -30,11 +25,10 @@ struct TotalTrainingResult: Equatable {
     init(_ diary: Diary) {
         
         trainingCount = diary.goals.count
-        startDateDisplayText = Self.getDisplayDateText(diary.createdAt)
+        startDateDisplayText = Self.getDisplayDateText(date: diary.createdAt)
         
         if case .finished(let info) = diary.status {
             
-            endDateDisplayText = Self.getDisplayDateText(info.endTime)
             totalTrainingTimeDurationText = Self.getTotalTrainingTimeDurationText(
                 from: diary.createdAt,
                 to: info.endTime
@@ -42,7 +36,6 @@ struct TotalTrainingResult: Equatable {
         }
         else {
             
-            endDateDisplayText = Self.defaultDateDisplayText
             totalTrainingTimeDurationText = Self.defaultDateDisplayText
         }
     }
@@ -50,15 +43,19 @@ struct TotalTrainingResult: Equatable {
 
 private extension TotalTrainingResult {
     
-    static func getDisplayDateText(_ date: Date) -> String {
+    static func getDisplayDateText(date: Date) -> String {
         
-        return date.formatted(Self.displayDateFormat,
-                              timeZone: .autoupdatingCurrent)
+        return date.formatted(.localDate)
     }
     
-    static func getTotalTrainingTimeDurationText(from startDate: Date, to endDate: Date?) -> String {
+    static func getTotalTrainingTimeDurationText(from startDate: Date,
+                                                 to endDate: Date?) -> String {
         
         guard let endDate else { return Self.defaultDateDisplayText }
-        return getDisplayDateText(Date(timeIntervalSince1970: endDate.timeIntervalSince(startDate)))
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = .pad
+        return formatter.string(from: startDate, to: endDate) ?? Self.defaultDateDisplayText
     }
 }

--- a/Macho/MachoFramework/Tests/MachoViewTests/Views/DiaryDetail/TotalTrainingResultTest.swift
+++ b/Macho/MachoFramework/Tests/MachoViewTests/Views/DiaryDetail/TotalTrainingResultTest.swift
@@ -1,0 +1,46 @@
+//
+//  MachoFramework
+//
+//  TotalTrainingResultTest.swift
+//
+//  Created by stotic-dev on 2025/07/05
+//  Copyright © Macho All rights reserved.
+//
+
+import Foundation
+import Testing
+
+@testable import MachoView
+
+struct TotalTrainingResultTest {
+
+    @Test(arguments: [
+        (Date.create(year: 2025, month: 1, day: 1, hour: 14), "02:00:00"),
+        (Date.create(year: 2025, month: 1, day: 1, hour: 12, second: 40), "00:00:40")
+    ])
+    func 終了済みのトレーニング結果では総トレーニング時間も表示する(endTime: Date, expectedDuration: String) async throws {
+        let target = TotalTrainingResult(
+            .create(
+                date: .create(year: 2025, month: 1, day: 1, hour: 12),
+                endTime: endTime
+            )
+        )
+        
+        #expect(target.startDateDisplayText == "2025年1月1日")
+        #expect(target.totalTrainingTimeDurationText == expectedDuration)
+        #expect(target.trainingCount == 0)
+    }
+
+    @Test func トレーニング未完了時はデフォルト文言を表示する() async throws {
+        let target = TotalTrainingResult(
+            .create(
+                date: .create(year: 2025, month: 1, day: 1, hour: 12),
+                endTime: nil
+            )
+        )
+        #expect(target.startDateDisplayText == "2025年1月1日")
+        #expect(target.totalTrainingTimeDurationText == "まだ記録されていません")
+        #expect(target.trainingCount == 0)
+    }
+
+}


### PR DESCRIPTION
## 関連Issue

## 概要
トレーニング中もトレーニング総時間が表示されているのが違和感だったので、トレーニング中は非表示にしようと思います。
また、トレーニング開始時間と終了時間の表示で、時間だけでなく年月日が表示されているのがみづらかったので、トレーニング開始日と総時間だけを表示するように修正します。

## 変更点

- トレーニング中は、トレーニングそう時間は表示しないようにしました
<img width="300" src="https://github.com/user-attachments/assets/03f2745d-b3de-474f-9947-1cbd0a993449"/>

- トレーニング終了後は、トレーニング総時間を表示するようにしました（hh:mm:SS形式）
<img width="300" src="https://github.com/user-attachments/assets/0cb60d78-28b7-4efb-83b8-085ed4249357"/>

## 影響範囲
日記詳細画面

## 動作確認

- シミュレーターで想定通り表示されることを確認
- UTが成功すること
